### PR TITLE
refactor settings between geoserver and qgis

### DIFF
--- a/geonode/local_settings.py.geoserver.sample
+++ b/geonode/local_settings.py.geoserver.sample
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+SITEURL = "http://localhost:8000/"
+
+DATABASES = {
+    'default': {
+         'ENGINE': 'django.db.backends.postgresql_psycopg2',
+         'NAME': 'geonode',
+         'USER': 'geonode',
+         'PASSWORD': 'geonode',
+     },
+    # vector datastore for uploads
+    'datastore' : {
+        #'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'ENGINE': '', # Empty ENGINE name disables
+        'NAME': 'geonode',
+        'USER' : 'geonode',
+        'PASSWORD' : 'geonode',
+        'HOST' : 'localhost',
+        'PORT' : '5432',
+    }
+}
+
+# OGC (WMS/WFS/WCS) Server Settings
+OGC_SERVER = {
+    'default' : {
+        'BACKEND' : 'geonode.geoserver',
+        'LOCATION' : 'http://localhost:8080/geoserver/',
+        'PUBLIC_LOCATION' : 'http://localhost:8080/geoserver/',
+        'USER' : 'admin',
+        'PASSWORD' : 'geoserver',
+        'MAPFISH_PRINT_ENABLED' : True,
+        'PRINT_NG_ENABLED' : True,
+        'GEONODE_SECURITY_ENABLED' : True,
+        'GEOGIG_ENABLED' : False,
+        'WMST_ENABLED' : False,
+        'BACKEND_WRITE_ENABLED': True,
+        'WPS_ENABLED' : False,
+        'LOG_FILE': '%s/geoserver/data/logs/geoserver.log' % os.path.abspath(os.path.join(PROJECT_ROOT, os.pardir)),
+        # Set to dictionary identifier of database containing spatial data in DATABASES dictionary to enable
+        'DATASTORE': '', #'datastore',
+    }
+}
+
+# If you want to enable Mosaics use the following configuration
+#UPLOADER = {
+##    'BACKEND': 'geonode.rest',
+#    'BACKEND': 'geonode.importer',
+#    'OPTIONS': {
+#        'TIME_ENABLED': True,
+#        'MOSAIC_ENABLED': True,
+#        'GEOGIG_ENABLED': False,
+#    }
+#}
+
+
+CATALOGUE = {
+    'default': {
+        # The underlying CSW implementation
+        # default is pycsw in local mode (tied directly to GeoNode Django DB)
+        'ENGINE': 'geonode.catalogue.backends.pycsw_local',
+        # pycsw in non-local mode
+        # 'ENGINE': 'geonode.catalogue.backends.pycsw_http',
+        # GeoNetwork opensource
+        # 'ENGINE': 'geonode.catalogue.backends.geonetwork',
+        # deegree and others
+        # 'ENGINE': 'geonode.catalogue.backends.generic',
+
+        # The FULLY QUALIFIED base url to the CSW instance for this GeoNode
+        'URL': '%scatalogue/csw' % SITEURL,
+        # 'URL': 'http://localhost:8080/geonetwork/srv/en/csw',
+        # 'URL': 'http://localhost:8080/deegree-csw-demo-3.0.4/services',
+
+        # login credentials (for GeoNetwork)
+        'USER': 'admin',
+        'PASSWORD': 'admin',
+    }
+}
+
+# Default preview library
+#LAYER_PREVIEW_LIBRARY = 'geoext'

--- a/geonode/local_settings.py.qgis.sample
+++ b/geonode/local_settings.py.qgis.sample
@@ -25,60 +25,16 @@ PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 SITEURL = "http://localhost:8000/"
 
+TIME_ZONE = 'America/Chicago'
+
 DATABASES = {
     'default': {
          'ENGINE': 'django.db.backends.postgresql_psycopg2',
          'NAME': 'geonode',
          'USER': 'geonode',
          'PASSWORD': 'geonode',
-     },
-    # vector datastore for uploads
-    'datastore' : {
-        #'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'ENGINE': '', # Empty ENGINE name disables 
-        'NAME': 'geonode',
-        'USER' : 'geonode',
-        'PASSWORD' : 'geonode',
-        'HOST' : 'localhost',
-        'PORT' : '5432',
-    }
+     }
 }
-
-# OGC (WMS/WFS/WCS) Server Settings
-
-WMS_QGIS_SERVER = GEONODE_BASE_URL + 'qgis-server/'
-
-OGC_SERVER = {
-    'default' : {
-        'BACKEND' : 'geonode.geoserver',
-        'LOCATION' : 'http://localhost:8080/geoserver/',  # or use WMS_QGIS_SERVER
-        'PUBLIC_LOCATION' : 'http://localhost:8080/geoserver/',  # or use WMS_QGIS_SERVER
-        'USER' : 'admin',
-        'PASSWORD' : 'geoserver',
-        'MAPFISH_PRINT_ENABLED' : True,
-        'PRINT_NG_ENABLED' : True,
-        'GEONODE_SECURITY_ENABLED' : True,
-        'GEOGIG_ENABLED' : False,
-        'WMST_ENABLED' : False,
-        'BACKEND_WRITE_ENABLED': True,
-        'WPS_ENABLED' : False,
-        'LOG_FILE': '%s/geoserver/data/logs/geoserver.log' % os.path.abspath(os.path.join(PROJECT_ROOT, os.pardir)),
-        # Set to dictionary identifier of database containing spatial data in DATABASES dictionary to enable
-        'DATASTORE': '', #'datastore',
-    }
-}
-
-# If you want to enable Mosaics use the following configuration
-#UPLOADER = {
-##    'BACKEND': 'geonode.rest',
-#    'BACKEND': 'geonode.importer',
-#    'OPTIONS': {
-#        'TIME_ENABLED': True,
-#        'MOSAIC_ENABLED': True,
-#        'GEOGIG_ENABLED': False,
-#    }
-#}
-
 
 CATALOGUE = {
     'default': {
@@ -103,10 +59,8 @@ CATALOGUE = {
     }
 }
 
-# Default preview library
-#LAYER_PREVIEW_LIBRARY = 'geoext'
-
-# Leaflet config if you use one
+# Leaflet config
+LAYER_PREVIEW_LIBRARY = 'leaflet'
 LEAFLET_CONFIG = {
     'TILES': [
         # Find tiles at:
@@ -147,6 +101,15 @@ LEAFLET_CONFIG = {
     'RESET_VIEW': False
 }
 
+# Legacy from Geoserver
+OGC_SERVER = {
+    'default': {
+        'LOCATION': SITEURL + 'qgis-server/',
+        'PUBLIC_LOCATION': SITEURL + 'qgis-server/'
+    }
+}
+
+# OGC (WMS/WFS/WCS) Server Settings
 tiles_directory = os.path.join(PROJECT_ROOT, "qgis_tiles")
 QGIS_SERVER_CONFIG = {
     'tiles_directory': tiles_directory,
@@ -155,37 +118,6 @@ QGIS_SERVER_CONFIG = {
     'thumbnail_path': tiles_directory + '/%s/thumbnail.png',
     'map_tile_path': os.path.join(
         tiles_directory, '%s', 'map_tiles', '%s', '%s', '%s', '%s.png'),
-    'qgis_server_url': 'http://127.0.0.1:9995/cgi-bin/qgis_mapserv.fcgi',
+    'qgis_server_url': 'http://127.0.0.1/cgi-bin/qgis_mapserv.fcgi',
     'layer_directory': os.path.join(PROJECT_ROOT, "qgis_layer")
-}
-
-# base url used to resolve layer files accessed by InaSAFE Headless
-GEONODE_BASE_URL = 'http://localhost:8000/'
-WMS_QGIS_SERVER = GEONODE_BASE_URL + 'qgis-server/'
-
-
-OGC_SERVER = {
-    'default': {
-        'BACKEND': 'geonode.geoserver',
-        'LOCATION': WMS_QGIS_SERVER,
-        # PUBLIC_LOCATION needs to be kept like this because in dev mode
-        # the proxy won't work and the integration tests will fail
-        # the entire block has to be overridden in the local_settings
-        'PUBLIC_LOCATION': WMS_QGIS_SERVER,
-        # 'LOCATION' : 'http://localhost:8080/geoserver/',  # or use WMS_QGIS_SERVER
-        # 'PUBLIC_LOCATION' : 'http://localhost:8080/geoserver/',  # or use WMS_QGIS_SERVER
-        'USER': 'admin',
-        'PASSWORD': 'geoserver',
-        'MAPFISH_PRINT_ENABLED': False,
-        'PRINT_NG_ENABLED': True,
-        'GEONODE_SECURITY_ENABLED': True,
-        'GEOGIG_ENABLED': False,
-        'WMST_ENABLED': False,
-        'BACKEND_WRITE_ENABLED': True,
-        'WPS_ENABLED': False,
-        'LOG_FILE': '%s/geoserver/data/logs/geoserver.log' % os.path.abspath(os.path.join(PROJECT_ROOT, os.pardir)),
-        # Set to name of database in DATABASES dictionary to enable
-        'DATASTORE': '',  # 'datastore',
-        'TIMEOUT': 10  # number of seconds to allow for HTTP requests
-    }
 }

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -172,7 +172,7 @@ def qgis_server_post_save(instance, sender, **kwargs):
     )
 
     # Create thumbnail
-    thumbnail_remote_url = settings.GEONODE_BASE_URL[:-1]
+    thumbnail_remote_url = settings.SITEURL[:-1]
     thumbnail_remote_url += reverse(
         'qgis-server-thumbnail', kwargs={'layername': instance.name})
     logger.debug(thumbnail_remote_url)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -968,13 +968,9 @@ if 'geonode.qgis_server' in INSTALLED_APPS:
         'tile_path': tiles_directory + '/%s/%d/%d/%d.png',
         'legend_path': tiles_directory + '/%s/legend.png',
         'thumbnail_path': tiles_directory + '/%s/thumbnail.png',
-        'qgis_server_url': 'http://127.0.0.1/qgisltr',
+        'qgis_server_url': 'http://127.0.0.1/cgi-bin/qgis_mapserv.fcgi',
         'layer_directory': os.path.join(PROJECT_ROOT, "qgis_layer")
     }
-
-# This settings here is needed to construct url for InaSAFE-Headless celery
-# batch. Note, trailing slash is important
-GEONODE_BASE_URL = 'http://localhost:8000/'
 
 # Load more settings from a file called local_settings.py if it exists
 try:


### PR DESCRIPTION
I tried to clean a little bit the settings.
Some settings about geoserver where useless in our project.

@lucernae I think you should make a `local_settings.py.inasafe.sample` with your celery and inasafe headless inside and remove everything from settings.py and local_settings.