### PR TITLE
fix too many geoserver warning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: python
 
 python:
@@ -5,6 +7,11 @@ python:
 
 virtualenv:
   system_site_packages: true
+
+services:
+  - docker
+  # GeoServer used Rabbitmq for notifier services
+  - rabbitmq
 
 branches:
   only:
@@ -17,10 +24,13 @@ install:
   - sudo apt-get install -y python-virtualenv python-imaging python-lxml python-pyproj python-shapely python-nose python-httplib2 python-httplib2 gettext
   - sudo add-apt-repository -y ppa:webupd8team/java
   - sudo apt-get update
-  - sudo apt-get install -y --force-yes oracle-java8-installer ant maven2 libjai-imageio-core-java --no-install-recommends
+  - sudo apt-get install -y --force-yes oracle-java8-installer ant maven2 libjai-core-java --no-install-recommends
+  # install libjai-imageio-core-java in trusty
+  - wget https://launchpad.net/ubuntu/+archive/primary/+files/libjai-imageio-core-java_1.2-3_amd64.deb
+  - sudo dpkg -i libjai-imageio-core-java_1.2-3_amd64.deb
   - sudo update-java-alternatives --set java-8-oracle
-  - pip install -r requirements.txt --use-mirrors
-  - pip install -e . --use-mirrors --no-deps
+  - pip install -r requirements.txt
+  - pip install -e . --no-deps
   - pip install coveralls
 
 before_script:

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -256,6 +256,27 @@ def set_geofence_all(instance):
             payload = payload + resource.layer.name
             payload = payload + "</layer><access>ALLOW</access></Rule>"
 
+            # Check rules already exists
+            params = {
+                'workspace': 'geonode',
+                'layer': resource.layer.name
+            }
+
+            r = requests.get(url + 'geofence/rest/rules.json',
+                             params=params,
+                             auth=HTTPBasicAuth(user, passwd))
+            if r.status_code == 200:
+                gs_rules = r.json()
+                for rule in gs_rules['rules']:
+                    workspace = rule['workspace']
+                    layer = rule['layer']
+                    access = rule['access']
+                    if (workspace == 'geonode' and
+                            layer == resource.layer.name and
+                            access.lower() == 'allow'):
+                        # Do not recreate a rule
+                        return
+
             r = requests.post(url + 'geofence/rest/rules',
                               headers=headers,
                               data=payload,


### PR DESCRIPTION
* Add rabbitmq service by switching to VM based travis

There were too many connection errors related with notification
services in GeoServer, because it can't found rabbitmq. Spin up
rabbitmq instances to handle this.

* Avoid posting duplicate geofence rules for anonymous

There were too many warning on duplicate geofence rule for anonymous
layer. Do some checks if a certain layer already has rule, do not
attempt to post the same rule.