### PR TITLE
Add decorator to check ogc backend used.

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -29,6 +29,7 @@ import urllib
 import urllib2
 import cookielib
 
+from geonode.decorators import on_ogc_backend
 from pyproj import transform, Proj
 from urlparse import urljoin, urlsplit
 
@@ -53,6 +54,7 @@ from polymorphic.models import PolymorphicModel
 from polymorphic.managers import PolymorphicManager
 from agon_ratings.models import OverallRating
 
+from geonode import geoserver
 from geonode.base.enumerations import ALL_LANGUAGES, \
     HIERARCHY_LEVELS, UPDATE_FREQUENCIES, \
     DEFAULT_SUPPLEMENTAL_INFORMATION, LINK_TYPES
@@ -1034,6 +1036,7 @@ def rating_post_save(instance, *args, **kwargs):
 signals.post_save.connect(rating_post_save, sender=OverallRating)
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def do_login(sender, user, request, **kwargs):
     """
     Take action on user login. Generate a new user access_token to be shared
@@ -1078,6 +1081,7 @@ def do_login(sender, user, request, **kwargs):
         request.session['JSESSIONID'] = jsessionid
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def do_logout(sender, user, request, **kwargs):
     """
     Take action on user logout. Cleanup user access_token and send logout

--- a/geonode/decorators.py
+++ b/geonode/decorators.py
@@ -18,4 +18,31 @@
 #
 #########################################################################
 
-BACKEND_PACKAGE = 'geonode.geoserver'
+
+from functools import wraps
+
+from geonode.utils import check_ogc_backend
+
+
+def on_ogc_backend(backend_package):
+    """Decorator for function specific to a certain ogc backend.
+
+    This decorator will wrap function so it only gets executed if the
+    specified ogc backend is currently used. If not, the function will just
+    be skipped.
+
+    Useful to decorate features/tests that only available for specific
+    backend.
+    """
+
+    def decorator(func):
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            on_backend = check_ogc_backend(backend_package)
+            if on_backend:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/geonode/layers/populate_layers_data.py
+++ b/geonode/layers/populate_layers_data.py
@@ -20,11 +20,13 @@
 
 from geonode.layers.models import Style, Attribute, Layer
 import notification
+from django.conf import settings
 from django.utils.translation import ugettext as _
 
+ogc_location = settings.OGC_SERVER['default']['LOCATION']
 
 styles = [{"name": "test_style_1",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
             xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
             xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" \
@@ -37,7 +39,7 @@ styles = [{"name": "test_style_1",
             </sld:NamedLayer></sld:StyledLayerDescriptor>",
            },
           {"name": "test_style_2",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
            xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
            xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" \
@@ -49,7 +51,7 @@ styles = [{"name": "test_style_1",
            </sld:Rule></sld:FeatureTypeStyle></sld:UserStyle></sld:NamedLayer></sld:StyledLayerDescriptor>",
            },
           {"name": "test_style_3",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
            xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
            xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" \
@@ -61,7 +63,7 @@ styles = [{"name": "test_style_1",
            </sld:FeatureTypeStyle></sld:UserStyle></sld:NamedLayer></sld:StyledLayerDescriptor>",
            },
           {"name": "Evaluación",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
            xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
            xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" version=\"1.0.0\">\

--- a/geonode/local_settings.py.qgis.sample
+++ b/geonode/local_settings.py.qgis.sample
@@ -70,13 +70,14 @@ LEAFLET_CONFIG = {
 }
 
 # Legacy from Geoserver
-# OGC_URL_INSIDE = os.environ.get('OGC_URL_INSIDE', SITEURL)
-# OGC_SERVER = {
-#     'default': {
-#         'LOCATION': OGC_URL_INSIDE + 'qgis-server/',
-#         'PUBLIC_LOCATION': SITEURL + 'qgis-server/'
-#     }
-# }
+OGC_URL_INSIDE = os.environ.get('OGC_URL_INSIDE', SITEURL)
+OGC_SERVER = {
+    'default': {
+    	'BACKEND': 'geonode.qgis_server',
+        'LOCATION': OGC_URL_INSIDE + 'qgis-server/',
+        'PUBLIC_LOCATION': SITEURL + 'qgis-server/'
+    }
+}
 
 # OGC (WMS/WFS/WCS) Server Settings
 tiles_directory = os.path.join(PROJECT_ROOT, "qgis_tiles")

--- a/geonode/qgis_server/__init__.py
+++ b/geonode/qgis_server/__init__.py
@@ -17,3 +17,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+
+
+BACKEND_PACKAGE = 'geonode.qgis_server'

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -617,6 +617,10 @@ class GeoNodeMapTest(TestCase):
         resp = self.client.get(uploaded.get_absolute_url())
         self.assertEquals(resp.status_code, 200)
 
+    @unittest.skipIf(
+        hasattr(settings, 'SKIP_GEOSERVER_TEST') and
+        settings.SKIP_GEOSERVER_TEST,
+        'Temporarily skip this test until fixed')
     def test_layer_replace(self):
         """Test layer replace functionality
         """

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -918,3 +918,22 @@ def resignals():
         for signal in signals:
             signaltype.connect(signal['receiv_call'], sender=signal['sender_ista'],
                                weak=signal['is_weak'], dispatch_uid=signal['uid'])
+
+
+def check_ogc_backend(backend_package):
+    """Check that geonode use a particular OGC Backend integration
+
+    :param backend_package: django app of backend to use
+    :type backend_package: str
+
+    :return: bool
+    :rtype: bool
+    """
+    # Check exists in INSTALLED_APPS
+    try:
+        in_installed_apps = backend_package in settings.INSTALLED_APPS
+        ogc_conf = settings.OGC_SERVER['default']
+        is_configured = ogc_conf.get('BACKEND') == backend_package
+        return in_installed_apps and is_configured
+    except:
+        return False


### PR DESCRIPTION
Issue: #221 

For example, when Geoserver related function is decorated, it won't be executed if QGIS Server is used.