### PR TITLE
Add ASCII file to geonode.

### DIFF
--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -137,8 +137,8 @@ class LayerUploadForm(forms.Form):
         if not cleaned["metadata_upload_form"] and base_ext.lower() not in (
                 ".shp", ".tif", ".tiff", ".geotif", ".geotiff", ".asc"):
             raise forms.ValidationError(
-                "Only Shapefiles and GeoTiffs are supported. You uploaded a %s file" %
-                base_ext)
+                "Only Shapefiles, GeoTiffs, and ASCIIs are supported. You "
+                "uploaded a %s file" % base_ext)
         elif cleaned["metadata_upload_form"] and base_ext.lower() not in (".xml"):
             raise forms.ValidationError(
                 "Only XML files are supported. You uploaded a %s file" %

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -134,7 +134,8 @@ class LayerUploadForm(forms.Form):
             if cleaned["xml_file"] is not None:
                 xml_file = cleaned["xml_file"].name
 
-        if not cleaned["metadata_upload_form"] and base_ext.lower() not in (".shp", ".tif", ".tiff", ".geotif", ".geotiff"):
+        if not cleaned["metadata_upload_form"] and base_ext.lower() not in (
+                ".shp", ".tif", ".tiff", ".geotif", ".geotiff", ".asc"):
             raise forms.ValidationError(
                 "Only Shapefiles and GeoTiffs are supported. You uploaded a %s file" %
                 base_ext)

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -44,7 +44,7 @@ csv_exts = ['.csv']
 kml_exts = ['.kml']
 vec_exts = shp_exts + csv_exts + kml_exts
 
-cov_exts = ['.tif', '.tiff', '.geotiff', '.geotif']
+cov_exts = ['.tif', '.tiff', '.geotiff', '.geotif', '.asc']
 
 TIME_REGEX = (
     ('[0-9]{8}', _('YYYYMMDD')),
@@ -207,7 +207,7 @@ class Layer(ResourceBase):
         if base_files_count == 0:
             return None, None
 
-        msg = 'There should only be one main file (.shp or .geotiff), found %s' % base_files_count
+        msg = 'There should only be one main file (.shp or .geotiff or .asc), found %s' % base_files_count
         assert base_files_count == 1, msg
 
         # we need to check, for shapefile, if column names are valid

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -297,6 +297,13 @@ class LayersTest(TestCase):
         files = dict(base_file=SimpleUploadedFile('foo.GEOTIF', ' '))
         self.assertTrue(LayerUploadForm(dict(), files).is_valid())
 
+    def testASCIIValidation(self):
+        files = dict(base_file=SimpleUploadedFile('foo.asc', ' '))
+        self.assertTrue(LayerUploadForm(dict(), files).is_valid())
+
+        files = dict(base_file=SimpleUploadedFile('foo.ASC', ' '))
+        self.assertTrue(LayerUploadForm(dict(), files).is_valid())
+
     def testZipValidation(self):
         the_zip = zipfile.ZipFile('test_upload.zip', 'w')
         in_memory_file = StringIO.StringIO()
@@ -355,6 +362,9 @@ class LayersTest(TestCase):
         self.assertEquals(layer_type('foo.geotiff'), 'raster')
         self.assertEquals(layer_type('foo.GEOTIFF'), 'raster')
         self.assertEquals(layer_type('foo.gEoTiFf'), 'raster')
+        self.assertEquals(layer_type('foo.asc'), 'raster')
+        self.assertEquals(layer_type('foo.ASC'), 'raster')
+        self.assertEquals(layer_type('foo.AsC'), 'raster')
 
         # basically anything else should produce a GeoNodeException
         self.assertRaises(GeoNodeException, lambda: layer_type('foo.gml'))

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -45,6 +45,8 @@ class QGISServerLayer(models.Model):
 
     geotiff_format = ['tif', 'tiff']
 
+    ascii_format = ['asc']
+
     layer = models.OneToOneField(
         Layer,
         primary_key=True,

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -195,22 +195,41 @@ def qgis_server_post_save(instance, sender, **kwargs):
         )
     )
 
-    # geotiff link
-    geotiff_url = reverse(
-        'qgis-server-geotiff', kwargs={'layername': instance.name})
-    geotiff_url = urljoin(base_url, geotiff_url)
-    logger.debug('geotif_url: %s' % geotiff_url)
+    if original_ext.split('.')[-1] in QGISServerLayer.geotiff_format:
+        # geotiff link
+        geotiff_url = reverse(
+            'qgis-server-geotiff', kwargs={'layername': instance.name})
+        geotiff_url = urljoin(base_url, geotiff_url)
+        logger.debug('geotif_url: %s' % geotiff_url)
 
-    Link.objects.get_or_create(
-        resource=instance.resourcebase_ptr,
-        url=geotiff_url,
-        defaults=dict(
-            extension='tif',
-            name="GeoTIFF",
-            mime='image/tif',
-            link_type='image'
+        Link.objects.get_or_create(
+            resource=instance.resourcebase_ptr,
+            url=geotiff_url,
+            defaults=dict(
+                extension='tif',
+                name="GeoTIFF",
+                mime='image/tif',
+                link_type='image'
+            )
         )
-    )
+
+    if original_ext.split('.')[-1] in QGISServerLayer.ascii_format:
+        # ascii link
+        ascii_url = reverse(
+            'qgis-server-ascii', kwargs={'layername': instance.name})
+        ascii_url = urljoin(base_url, ascii_url)
+        logger.debug('ascii_url: %s' % ascii_url)
+
+        Link.objects.get_or_create(
+            resource=instance.resourcebase_ptr,
+            url=ascii_url,
+            defaults=dict(
+                extension='asc',
+                name="ASCII",
+                mime='image/tif',
+                link_type='image'
+            )
+        )
 
     # Create legend link
     legend_url = reverse(

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -29,7 +29,8 @@ from geonode.qgis_server.views import (
     qgis_server_request,
     qgis_server_pdf,
     qgis_server_map_print,
-    geotiff
+    geotiff,
+    ascii
 )
 
 
@@ -59,6 +60,14 @@ urlpatterns = patterns(
         r'(?:&access_token=(?P<access_token>[\w]*))?$',
         geotiff,
         name='qgis-server-geotiff'
+    ),
+    url(
+        r'^qgis-server/ascii/'
+        r'(?P<layername>[\w]*)'
+        r'[\?]?'
+        r'(?:&access_token=(?P<access_token>[\w]*))?$',
+        ascii,
+        name='qgis-server-ascii'
     ),
     url(
         r'^qgis-server/legend/(?P<layername>[\w]*)'

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -378,19 +378,8 @@ def geotiff(request, layername, access_token=None):
 
 
 def ascii(request, layername, access_token=None):
-    try:
-        layer = Layer.objects.get(name=layername)
-    except ObjectDoesNotExist:
-        msg = 'No layer found for %s' % layername
-        logger.debug(msg)
-        raise Http404(msg)
-
-    try:
-        qgis_layer = QGISServerLayer.objects.get(layer=layer)
-    except ObjectDoesNotExist:
-        msg = 'No QGIS Server Layer for existing layer %s' % layername
-        logger.debug(msg)
-        return Http404(msg)
+    layer = get_object_or_404(Layer, name=layername)
+    qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
 
     basename, _ = os.path.splitext(qgis_layer.base_layer_path)
 

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -376,6 +376,7 @@ def geotiff(request, layername, access_token=None):
     with open(filename, 'rb') as f:
         return HttpResponse(f.read(), content_type='image/tiff')
 
+
 def ascii(request, layername, access_token=None):
     try:
         layer = Layer.objects.get(name=layername)
@@ -409,6 +410,7 @@ def ascii(request, layername, access_token=None):
 
     with open(filename, 'rb') as f:
         return HttpResponse(f.read(), content_type='text/asc')
+
 
 def qgis_server_request(request):
     """View to forward OGC request to QGIS Server."""

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -880,7 +880,8 @@ DOWNLOAD_FORMATS_RASTER = [
     'View in Google Earth',
     'Tiles',
     'GML',
-    'GZIP'
+    'GZIP',
+    'ASCII'
 ]
 
 ACCOUNT_NOTIFY_ON_PASSWORD_CHANGE = False

--- a/geonode/static/geonode/js/upload/FileTypes.js
+++ b/geonode/static/geonode/js/upload/FileTypes.js
@@ -9,6 +9,11 @@ define(['./FileType'], function (FileType) {
             main: 'shp',
             requires: ['shp', 'prj', 'dbf', 'shx']
         });
+    file_types['ASCII'] = new FileType({
+            name: gettext('ASCII Text File'),
+            format: 'raster',
+            main: 'asc'
+        });
     file_types['TIF'] = new FileType({
             name: gettext('GeoTIFF'),
             format: 'raster',

--- a/geonode/upload/files.py
+++ b/geonode/upload/files.py
@@ -126,6 +126,8 @@ types = [
              auxillary_file_exts=('dbf', 'shx', 'prj')),
     FileType("GeoTIFF", "tif", raster,
              aliases=('tiff', 'geotif', 'geotiff')),
+    FileType("ASCII Text File", "asc", raster,
+             auxillary_file_exts=('prj')),
     # requires geoserver importer extension
     FileType("PNG", "png", raster,
              auxillary_file_exts=('prj')),

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -572,6 +572,7 @@ _steps = {
 _pages = {
     'shp': ('srs', 'time', 'run', 'final'),
     'tif': ('run', 'final'),
+    'asc': ('run', 'final'),
     'kml': ('run', 'final'),
     'csv': ('csv', 'time', 'run', 'final'),
     'geojson': ('run', 'final'),


### PR DESCRIPTION
Partial fix for #159 

Current state:
  - We can't upload asc file
  - We can upload tif file

This PR will make geonode able to upload asc file. We need to enable it first before we can download the asc file.