### PR TITLE
Fix maps test for qgis_server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ env:
     QGIS_SERVER_URL: http://localhost:9000/
     # This is the IP of docker network bridge
     # So QGIS server can access this address
-    SITEURL: http://172.17.0.1:8000/
+    SITEURL: http://localhost:8000/
+    GEONODE_PROJECT_PATH: /home/travis/build/kartoza/geonode/
     ON_TRAVIS: True
+    CELERY_ALWAYS_EAGER: True
 
 branches:
   only:

--- a/docker-compose-qgis-server.yml
+++ b/docker-compose-qgis-server.yml
@@ -4,7 +4,7 @@ services:
   qgis-server:
     image: kartoza/qgis-server:LTR
     volumes:
-      - './geonode:/usr/src/app'
+      - './:${GEONODE_PROJECT_PATH}'
       - './otf-project:/opt/qgis-server/plugins/otf-project'
     environment:
       - QGIS_LOG_FILE=/tmp/qgis-server/qgis.log

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -559,6 +559,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     @property
     def bbox(self):
+        """BBOX is in the format: [x0,y0,x1,y1]."""
         return [self.bbox_x0, self.bbox_y0, self.bbox_x1, self.bbox_y1, self.srid]
 
     @property
@@ -624,8 +625,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         Set the four bounds in lat lon projection
         """
         self.bbox_x0 = box[0]
-        self.bbox_x1 = box[1]
-        self.bbox_y0 = box[2]
+        self.bbox_y0 = box[1]
+        self.bbox_x1 = box[2]
         self.bbox_y1 = box[3]
 
     def set_bounds_from_center_and_zoom(self, center_x, center_y, zoom):
@@ -672,6 +673,10 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     def set_bounds_from_bbox(self, bbox):
         """
         Calculate zoom level and center coordinates in mercator.
+
+        :param bbox: BBOX is in the  format: [x0, y0, x1, y1], which is:
+            [min lon, min lat, max lon, max lat]
+        :type bbox: list
         """
         self.set_latlon_bounds(bbox)
 

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -49,6 +49,7 @@ from django.db.models.signals import pre_delete
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 import geoserver
+from geonode.maps.models import Map
 from geoserver.catalog import Catalog
 from geoserver.catalog import ConflictingDataError
 from geoserver.catalog import FailedRequestError, UploadError
@@ -1786,7 +1787,7 @@ def create_gs_thumbnail(instance, overwrite=False):
     """
     Create a thumbnail with a GeoServer request.
     """
-    if instance.class_name == 'Map':
+    if isinstance(instance, Map):
         local_layers = []
         for layer in instance.layers:
             if layer.local:

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -491,8 +491,8 @@ def pre_save_layer(instance, sender, **kwargs):
 
     bbox = [
         instance.bbox_x0,
-        instance.bbox_x1,
         instance.bbox_y0,
+        instance.bbox_x1,
         instance.bbox_y1]
 
     instance.set_bounds_from_bbox(bbox)

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -29,6 +29,7 @@ import glob
 import sys
 import tempfile
 
+from geonode.maps.models import Map
 from osgeo import gdal
 
 # Django functionality
@@ -45,7 +46,8 @@ from django.db.models import Q
 from geonode import GeoNodeException
 from geonode.people.utils import get_valid_user
 from geonode.layers.models import Layer, UploadSession
-from geonode.base.models import Link, SpatialRepresentationType, TopicCategory, Region, License
+from geonode.base.models import Link, SpatialRepresentationType, TopicCategory, Region, License, \
+    ResourceBase
 from geonode.layers.models import shp_exts, csv_exts, vec_exts, cov_exts
 from geonode.layers.metadata import set_metadata
 from geonode.utils import http_client
@@ -747,10 +749,15 @@ def upload(incoming, user=None, overwrite=False,
 def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
                      check_bbox=True, ogc_client=None, overwrite=False):
     thumbnail_dir = os.path.join(settings.MEDIA_ROOT, 'thumbs')
-    thumbnail_name = 'layer-%s-thumb.png' % instance.uuid
+    thumbnail_name = None
+    if isinstance(instance, Layer):
+        thumbnail_name = 'layer-%s-thumb.png' % instance.uuid
+    elif isinstance(instance, Map):
+        thumbnail_name = 'map-%s-thumb.png' % instance.uuid
     thumbnail_path = os.path.join(thumbnail_dir, thumbnail_name)
 
     if overwrite is True or storage.exists(thumbnail_path) is False:
+        logger.debug('Will fetch thumbnail %s' % thumbnail_remote_url)
         if not ogc_client:
             ogc_client = http_client
         BBOX_DIFFERENCE_THRESHOLD = 1e-5
@@ -777,6 +784,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
         image = None
 
         if valid_x and valid_y:
+            logger.debug('Valid bbox. Will create Remote Thumbnail Link.')
             Link.objects.get_or_create(resource=instance.get_self_resource(),
                                        url=thumbnail_remote_url,
                                        defaults=dict(
@@ -786,7 +794,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
                                            link_type='image',
                                            )
                                        )
-            Layer.objects.filter(id=instance.id) \
+            ResourceBase.objects.filter(id=instance.id) \
                 .update(thumbnail_url=thumbnail_remote_url)
             # Download thumbnail and save it locally.
             resp, image = ogc_client.request(thumbnail_create_url)
@@ -798,5 +806,4 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
                 image = None
 
         if image is not None:
-            filename = 'layer-%s-thumb.png' % instance.uuid
-            instance.save_thumbnail(filename, image=image)
+            instance.save_thumbnail(thumbnail_name, image=image)

--- a/geonode/local_settings.py.qgis.sample
+++ b/geonode/local_settings.py.qgis.sample
@@ -110,3 +110,5 @@ QGIS_SERVER_CONFIG = {
 
 on_travis = os.environ.get('ON_TRAVIS', False)
 SKIP_GEOSERVER_TEST = on_travis
+
+CELERY_ALWAYS_EAGER = os.environ.get('CELERY_ALWAYS_EAGER', True)

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -223,8 +223,8 @@ class Map(ResourceBase, GXPMapBase):
                 bbox = list(layer_bbox[0:4])
             else:
                 bbox[0] = min(bbox[0], layer_bbox[0])
-                bbox[1] = max(bbox[1], layer_bbox[1])
-                bbox[2] = min(bbox[2], layer_bbox[2])
+                bbox[1] = min(bbox[1], layer_bbox[1])
+                bbox[2] = max(bbox[2], layer_bbox[2])
                 bbox[3] = max(bbox[3], layer_bbox[3])
 
         return bbox
@@ -239,6 +239,9 @@ class Map(ResourceBase, GXPMapBase):
         self.center_y = 0
         bbox = None
         index = 0
+
+        if self.uuid is None or self.uuid == '':
+            self.uuid = str(uuid.uuid1())
 
         DEFAULT_MAP_CONFIG, DEFAULT_BASE_LAYERS = default_map_config(None)
 

--- a/geonode/maps/templates/maps/map_leaflet.html
+++ b/geonode/maps/templates/maps/map_leaflet.html
@@ -52,18 +52,44 @@
         /* add initial base layer to the map */
         map.addLayer(osm);
 
+        /* zoom to bbox */
+        firstProjection = proj4('{{ resource.srid }}');
+        var corner0 = [{{ resource.bbox_x0 }}, {{ resource.bbox_y0 }}];
+        var corner1 = [{{ resource.bbox_x1 }}, {{ resource.bbox_y1 }}];
+
+        corner0 = proj4(firstProjection, secondProjection, corner0);
+        corner1 = proj4(firstProjection, secondProjection, corner1);
+
+        var bbox = [
+            corner0[0],
+            corner0[1],
+            corner1[0],
+            corner1[1]
+        ];
+
+        zoom_to_box(map, bbox);
+
         /* loop over the layers used by the map */
         {% for layer in layers %}
             if ("{{ layer.group }}" != 'background') {
                 /* if current layer not a background layer, instantiates a WMS tile layer object 
                  * given the URL of the WMS service and a WMS parameters/options object.
                  */
-                wmsLayer = L.tileLayer.wms('{{ layer.ows_url }}', {
+                var layer_url = '{{  layer.ows_url }}';
+                var options = {
                     format: 'image/png',
                     transparent: true,
                     layers: '{{ layer.name }}',
-                    'opacity': 0.8
-                });   
+                    opacity: 0.8
+                };
+                /* Determine type of tileLayer */
+                if(layer_url.includes('{z}') && layer_url.includes('{y}') && layer_url.includes('{x}')){
+
+                    wmsLayer = L.tileLayer(layer_url, options);
+                }
+                else {
+                    wmsLayer = L.tileLayer.wms(layer_url, options);
+                }
                 /* add wmsLayer to the overlay_layers{} and to the map object itself */
                 if (wmsLayer != null) {
                     overlay_layers["{{ layer.layer_title }}"] = wmsLayer;

--- a/geonode/qgis_server/admin.py
+++ b/geonode/qgis_server/admin.py
@@ -29,4 +29,5 @@ class QGISServerLayerAdmin(admin.ModelAdmin):
         'base_layer_path'
     ]
 
+
 admin.site.register(QGISServerLayer, QGISServerLayerAdmin)

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -17,11 +17,18 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+import logging
+import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from geonode.qgis_server.models import QGISServerLayer
 
 from geonode import qgis_server
+from geonode.geoserver.helpers import OGC_Servers_Handler
+
+logger = logging.getLogger(__file__)
+ogc_server_settings = OGC_Servers_Handler(settings.OGC_SERVER)['default']
 
 
 def validate_django_settings():
@@ -82,3 +89,138 @@ def validate_django_settings():
             "{package}.".format(package=qgis_server.BACKEND_PACKAGE))
 
     return True
+
+
+def map_thumbnail_url(instance):
+    """Construct QGIS Server Url to fetch remote map thumbnail.
+
+    :param instance: Map object
+    :type instance: geonode.maps.models.Map
+
+    :return: thumbnail url
+    :rtype: str
+    """
+    map_id = instance.id
+    map_file = 'map_%s' % map_id
+    qgis_server_config = settings.QGIS_SERVER_CONFIG
+    map_project = os.path.join(
+        qgis_server_config['layer_directory'], '{0}.qgs'.format(map_file))
+    if not os.path.exists(map_project):
+        msg = 'Map project not found for %s' % map_project
+        logger.debug(msg)
+        return None
+
+    # We get the extent of these layers.
+    bbox = [float(i) for i in instance.bbox_string.split(',')]
+    x_min, y_min, x_max, y_max = bbox
+
+    # We calculate the margins according to 10 percent.
+    percent = 10
+    delta_x = (x_max - x_min) / 100 * percent
+    delta_y = (y_max - y_min) / 100 * percent
+
+    # We apply the margins to the extent.
+    margin = [
+        y_min - delta_y,
+        x_min - delta_x,
+        y_max + delta_y,
+        x_max + delta_x
+    ]
+
+    # Call the WMS.
+    bbox = ','.join([str(val) for val in margin])
+    qgis_server = qgis_server_config['qgis_server_url']
+    query_string = {
+        'SERVICE': 'WMS',
+        'VERSION': '1.3.0',
+        'REQUEST': 'GetMap',
+        'BBOX': bbox,
+        'CRS': 'EPSG:4326',
+        'WIDTH': '250',
+        'HEIGHT': '250',
+        'MAP': map_project,
+        'LAYERS': map_file,
+        'STYLES': 'default',
+        'FORMAT': 'image/png',
+        'TRANSPARENT': 'true',
+        'DPI': '96',
+        'MAP_RESOLUTION': '96',
+        'FORMAT_OPTIONS': 'dpi:96'
+    }
+
+    query_pairs = [
+        '{0}={1}'.format(param, value)
+        for param, value in query_string.iteritems()]
+    query_params = '&'.join(query_pairs)
+    url = qgis_server + '?' + query_params
+    return url
+
+
+def layer_thumbnail_url(instance):
+    """Construct QGIS Server Url to fetch remote layer thumbnail.
+
+    :param instance: Layer object
+    :type instance: geonode.layers.models.Layer
+
+    :return: thumbnail url
+    :rtype: str
+    """
+    qgis_server_config = settings.QGIS_SERVER_CONFIG
+
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=instance)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer %s' % instance.name
+        logger.debug(msg)
+        return None
+
+    basename, _ = os.path.splitext(qgis_layer.base_layer_path)
+
+    # We get the extent of the layer.
+    x_min = instance.resourcebase_ptr.bbox_x0
+    x_max = instance.resourcebase_ptr.bbox_x1
+    y_min = instance.resourcebase_ptr.bbox_y0
+    y_max = instance.resourcebase_ptr.bbox_y1
+
+    # We calculate the margins according to 10 percent.
+    percent = 10
+    delta_x = (x_max - x_min) / 100 * percent
+    delta_y = (y_max - y_min) / 100 * percent
+
+    # We apply the margins to the extent.
+    margin = [
+        y_min - delta_y,
+        x_min - delta_x,
+        y_max + delta_y,
+        x_max + delta_x
+    ]
+
+    # Call the WMS.
+    bbox = ','.join([str(val) for val in margin])
+
+    qgis_server = qgis_server_config['qgis_server_url']
+    query_string = {
+        'SERVICE': 'WMS',
+        'VERSION': '1.3.0',
+        'REQUEST': 'GetMap',
+        'BBOX': bbox,
+        'CRS': 'EPSG:4326',
+        'WIDTH': '250',
+        'HEIGHT': '250',
+        'MAP': basename + '.qgs',
+        'LAYERS': instance.name,
+        'STYLES': 'default',
+        'FORMAT': 'image/png',
+        'TRANSPARENT': 'true',
+        'DPI': '96',
+        'MAP_RESOLUTION': '96',
+        'FORMAT_OPTIONS': 'dpi:96'
+    }
+
+    query_pairs = [
+        '{0}={1}'.format(param, value)
+        for param, value in query_string.iteritems()]
+    query_params = '&'.join(query_pairs)
+    url = qgis_server + '?' + query_params
+
+    return url

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -80,4 +80,5 @@ class QGISServerLayer(models.Model):
         except OSError:
             pass
 
+
 from geonode.qgis_server import signals  # noqa: F402.F401

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -19,18 +19,16 @@
 #########################################################################
 
 from django.test import TestCase
-from django.test.client import RequestFactory
-
-from geonode.qgis_server.context_processors import qgis_server_urls
 
 
 class ViewsTest(TestCase):
 
     def test_default_context(self):
         """Test default context provided by qgis_server."""
-        request = RequestFactory().get('/')
 
-        context = qgis_server_urls(request)
+        response = self.client.get('/')
+
+        context = response.context
 
         # Necessary context to ensure compatibility with views
         # Some view needs these context to do some javascript logic.

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -24,8 +24,6 @@ from geonode.qgis_server.views import (
     download_zip,
     tile,
     legend,
-    thumbnail,
-    map_thumbnail,
     qgis_server_request,
     qgis_server_pdf,
     qgis_server_map_print,
@@ -73,16 +71,6 @@ urlpatterns = patterns(
     #     legend,
     #     name='qgis-server-legend'
     # ),
-    url(
-        r'^qgis-server/thumbnail/(?P<layername>[\w]*)$',
-        thumbnail,
-        name='qgis-server-thumbnail'
-    ),
-    url(
-        r'^qgis-server/map/thumbnail/(?P<map_id>[\w]*)$',
-        map_thumbnail,
-        name='qgis-server-map-thumbnail'
-    ),
     # WMS entry point, this URL is not specific to WMS, you should remove it ?
     url(
         r'^qgis-server/wms/$',

--- a/pavement.py
+++ b/pavement.py
@@ -436,8 +436,8 @@ def test(options):
     """
     Run GeoNode's Unit Test Suite
     """
-    sh("%s manage.py test %s.tests --noinput" % (options.get('prefix'),
-                                                 '.tests '.join(GEONODE_APPS)))
+    sh("%s manage.py test %s.tests --noinput --liveserver=0.0.0.0:8000" % (
+        options.get('prefix'), '.tests '.join(GEONODE_APPS)))
 
 
 @task

--- a/scripts/misc/qgis_server_setup.sh
+++ b/scripts/misc/qgis_server_setup.sh
@@ -18,9 +18,17 @@ if [ $BACKEND = "geonode.qgis_server" ] && [ $1 = "before_script" ]; then
 	cd otf-project
 	git checkout master
 	cd ../
+	echo "Create QGIS Server related folder"
+	mkdir -p geonode/qgis_layer
+	mkdir -p geonode/qgis_tiles
+	chmod 777 geonode/qgis_layer
+	chmod 777 geonode/qgis_tiles
 	echo "Start QGIS Server docker container"
 	docker-compose -f docker-compose-qgis-server.yml up -d qgis-server
 	docker ps
+	echo "Test connection to QGIS Server"
+	wget -qO- $QGIS_SERVER_URL
+	wget -qO- ${QGIS_SERVER_URL}?SERVICE=MAPCOMPOSITION
 	echo "Copy QGIS Server configuration"
 	cp geonode/local_settings.py.qgis.sample geonode/local_settings.py
 fi


### PR DESCRIPTION
- Refactor thumbnail url generator for QGIS Server. Now giving direct url to
  QGIS Server, instead of proxying to Django.

- Remove unnecessary thumbnail view in qgis_server, because geonode already
  have internal cache for thumbnail. Thumbnail should just be accessed
  directly to QGIS Server without proxy.

- Fix map creation test.

- Refactor wrong/inconsistent bbox convention for maps.