### PR TITLE
refactor URLs in qgis-server app

### DIFF
--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -19,9 +19,12 @@
 #########################################################################
 import logging
 import os
+from urlparse import urljoin
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.core.urlresolvers import reverse
+
 from geonode.qgis_server.models import QGISServerLayer
 
 from geonode import qgis_server
@@ -89,6 +92,29 @@ def validate_django_settings():
             "{package}.".format(package=qgis_server.BACKEND_PACKAGE))
 
     return True
+
+
+def tile_url(layer_name):
+    """Construct QGIS Server URL for tiles according to a layer.
+
+    :param layer_name: The layer name from the QGIS backend
+    :type layer_name: basestring
+
+    :return: Tile url
+    :rtype: basestring
+    """
+    # We request a fake tile to get the real URL.
+    url = reverse(
+        'qgis-server-tile',
+        kwargs={
+            'layername': layer_name,
+            'x': 5678,
+            'y': 910,
+            'z': 1234
+        })
+    url = urljoin(settings.SITEURL, url)
+    url = url.replace('1234/5678/910', '{z}/{x}/{y}')
+    return url
 
 
 def map_thumbnail_url(instance):

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -35,6 +35,7 @@ from geonode.layers.models import Layer
 from geonode.maps.models import Map, MapLayer
 from geonode.qgis_server.tasks.update import create_qgis_server_thumbnail
 from geonode.qgis_server.gis_tools import set_attributes
+from geonode.qgis_server.helpers import tile_url
 
 logger = logging.getLogger("geonode.qgis_server.signals")
 QGIS_layer_directory = settings.QGIS_SERVER_CONFIG['layer_directory']
@@ -181,22 +182,9 @@ def qgis_server_post_save(instance, sender, **kwargs):
     if data != 'OK':
         logger.debug('Result : %s' % data)
 
-    tile_url = reverse(
-        'qgis-server-tile',
-        kwargs={
-            'layername': instance.name,
-            'x': 5678,
-            'y': 910,
-            'z': 1234
-        })
-    tile_url = urljoin(base_url, tile_url)
-    logger.debug('tile_url: %s' % tile_url)
-    tile_url = tile_url.replace('1234/5678/910', '{z}/{x}/{y}')
-    logger.debug('tile_url: %s' % tile_url)
-
     Link.objects.get_or_create(
         resource=instance.resourcebase_ptr,
-        url=tile_url,
+        url=tile_url(instance.name),
         defaults=dict(
             extension='tiles',
             name="Tiles",

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -23,6 +23,7 @@ from django.conf.urls import patterns, url
 from geonode.qgis_server.views import (
     download_zip,
     tile,
+    tile_404,
     legend,
     qgis_server_request,
     qgis_server_pdf,
@@ -33,9 +34,11 @@ from geonode.qgis_server.views import (
 
 
 urlpatterns = patterns(
+
+    # Specific for a QGIS Layer
     '',
     url(
-        r'^qgis-server/download-zip/'
+        r'^download-zip/'
         r'(?P<layername>[\w]*)'
         r'[\?]?'
         r'(?:&access_token=(?P<access_token>[\w]*))?$',
@@ -43,8 +46,7 @@ urlpatterns = patterns(
         name='qgis-server-download-zip'
     ),
     url(
-        r'^qgis-server/'
-        r'tiles/'
+        r'^tiles/'
         r'(?P<layername>[^/]*)/'
         r'(?P<z>[0-9]*)/'
         r'(?P<x>[0-9]*)/'
@@ -53,7 +55,13 @@ urlpatterns = patterns(
         name='qgis-server-tile'
     ),
     url(
-        r'^qgis-server/geotiff/'
+        r'^tiles/'
+        r'(?P<layername>[^/]*)/\{z\}/\{x\}/\{y\}.png',
+        tile_404,
+        name='qgis-server-tile'
+    ),
+    url(
+        r'^geotiff/'
         r'(?P<layername>[\w]*)'
         r'[\?]?'
         r'(?:&access_token=(?P<access_token>[\w]*))?$',
@@ -61,7 +69,7 @@ urlpatterns = patterns(
         name='qgis-server-geotiff'
     ),
     url(
-        r'^qgis-server/ascii/'
+        r'^ascii/'
         r'(?P<layername>[\w]*)'
         r'[\?]?'
         r'(?:&access_token=(?P<access_token>[\w]*))?$',
@@ -69,37 +77,35 @@ urlpatterns = patterns(
         name='qgis-server-ascii'
     ),
     url(
-        r'^qgis-server/legend/(?P<layername>[\w]*)'
+        r'^legend/(?P<layername>[\w]*)'
         r'(?:/(?P<layertitle>[\w]*))?'
         r'[\?]?'
         r'(?:&access_token=(?P<access_token>[\w]*))?$',
         legend,
         name='qgis-server-legend'
     ),
-    # url(
-    #     r'^qgis-server/legend/(?P<layername>[^/]*)$',
-    #     legend,
-    #     name='qgis-server-legend'
-    # ),
+
+    # Generic for OGC
     # WMS entry point, this URL is not specific to WMS, you should remove it ?
     url(
-        r'^qgis-server/wms/$',
-        qgis_server_request,
-        name='qgis-server-request'
-    ),
-    # Generic OGC entry points
-    url(
-        r'^qgis-server/ogc/$',
+        r'^wms/$',
         qgis_server_request,
         name='qgis-server-request'
     ),
     url(
-        r'^qgis-server/pdf/info\.json$',
+        r'^ogc/$',
+        qgis_server_request,
+        name='qgis-server-request'
+    ),
+
+    # Generic for the app
+    url(
+        r'^pdf/info\.json$',
         qgis_server_pdf,
         name='qgis-server-pdf'
     ),
     url(
-        r'^qgis-server/map/print$',
+        r'^map/print$',
         qgis_server_map_print,
         name='qgis-server-map-print'
     ),

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -33,9 +33,11 @@ from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext as _
 
 from geonode.layers.models import Layer
 from geonode.qgis_server.gis_tools import num2deg
+from geonode.qgis_server.helpers import tile_url
 from geonode.qgis_server.models import QGISServerLayer
 
 logger = logging.getLogger('geonode.qgis_server.views')
@@ -135,6 +137,20 @@ def legend(request, layername, layertitle=None, access_token=None):
 
     with open(legend_filename, 'rb') as f:
         return HttpResponse(f.read(), content_type='image/png')
+
+
+def tile_404(request, layername):
+    """This view is used when the user try to use the raw tile URL.
+
+    When the URL contains {z}/{x}/{y}.png.
+    """
+    layer = get_object_or_404(Layer, name=layername)
+    get_object_or_404(QGISServerLayer, layer=layer)
+
+    msg = _(
+        'You should use a GIS software or a library which support TMS service '
+        'to use this URL : {url}').format(url=tile_url(layername))
+    return HttpResponse(msg)
 
 
 def tile(request, layername, z, x, y):

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -138,9 +138,9 @@ if 'geonode.geoserver' in settings.INSTALLED_APPS:
                             )
 if 'geonode.qgis_server' in settings.INSTALLED_APPS:
     # QGIS Server's urls
-    urlpatterns += patterns('',
-                            (r'', include('geonode.qgis_server.urls')),
-                            )
+    urlpatterns += patterns(
+        '', (r'^qgis-server/', include('geonode.qgis_server.urls')),
+    )
 
 if settings.NOTIFICATIONS_MODULE in settings.INSTALLED_APPS:
     notifications_urls = '{}.urls'.format(settings.NOTIFICATIONS_MODULE)


### PR DESCRIPTION
Maybe, before this PR, we need to fix the double qgis-server app in geonode urls.
If we go to : http://localhost/fake_url
We can see qgis-server urls are registered twice:
<img width="1248" alt="screen shot 2017-06-06 at 11 53 31" src="https://cloud.githubusercontent.com/assets/1609292/26813167/e0315e3a-4aae-11e7-8a06-6778ea4adbc4.png">

line 53 and 79-84

This PR also fixes the 404 page for the raw tile URL

BTW, @lucernae Shouldn't we do the same for geosafe? It's a good practice I think in django to have "subdomains" for each app. 