### PR TITLE
Make replace layer works with QGIS Server Backend.

### DIFF
--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -592,10 +592,6 @@ class GeoNodeMapTest(TestCase):
         resp = self.client.get(uploaded.get_absolute_url())
         self.assertEquals(resp.status_code, 200)
 
-    @unittest.skipIf(
-        hasattr(settings, 'SKIP_GEOSERVER_TEST') and
-        settings.SKIP_GEOSERVER_TEST,
-        'Temporarily skip this test until fixed')
     def test_layer_replace(self):
         """Test layer replace functionality
         """


### PR DESCRIPTION
This fix #108 

It seems there is not unit test to replace layer for geoserver. I will try to add one for qgis server backend.

Update: there is a unit test for it, I will try to unskip it for qgis server backend