### PR TITLE
Fix osgeo package not found in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+group: deprecated-2017Q2
+
 language: python
 
 python:


### PR DESCRIPTION
Travis does apparently update their ubuntu trusty image and somehow our build is failing because it doesn't found osgeo.

We used previous image now until Travis is fine and stable.