### PR TITLE
Additional features for Geonode - QGIS Server

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -106,8 +106,6 @@ class CommonModelApi(ModelResource):
         'thumbnail_url',
         'detail_url',
         'rating',
-        'typename',
-        'name'
     ]
 
     def build_filters(self, filters=None):
@@ -579,7 +577,12 @@ class LayerResource(CommonModelApi):
         formatted_objects = []
         for obj in objects:
             # convert the object to a dict using the standard values.
-            formatted_obj = model_to_dict(obj, fields=self.VALUES)
+            # includes other values
+            values = self.VALUES + [
+                'typename',
+                'name'
+            ]
+            formatted_obj = model_to_dict(obj, fields=values)
             # add the geogig link
             formatted_obj['geogig_link'] = obj.geogig_link
             # add Link link

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -133,6 +133,7 @@ def resource_urls(request):
             False
         ),
         THESAURI_FILTERS=[t['name'] for t in settings.THESAURI if t.get('filter')],
+        OGC_SERVER=getattr(settings, 'OGC_SERVER', None),
     )
     defaults['message_create_url'] = 'message_create' if not settings.USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS\
         else 'message_create_multiple'

--- a/geonode/layers/management/commands/delete_orphaned_layers.py
+++ b/geonode/layers/management/commands/delete_orphaned_layers.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.core.management.base import BaseCommand
+
+from geonode.layers.utils import delete_orphaned_layers
+
+
+class Command(BaseCommand):
+    help = ("Delete orphaned layers.")
+
+    def handle(self, *args, **options):
+        delete_orphaned_layers()

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -576,7 +576,17 @@ def post_delete_layer(instance, sender, **kwargs):
         pass
 
 
+def post_delete_layer_file(instance, sender, **kwargs):
+    """Delete associated file.
+
+    :param instance: LayerFile instance
+    :type instance: LayerFile
+    """
+    instance.file.delete(save=False)
+
+
 signals.pre_save.connect(pre_save_layer, sender=Layer)
 signals.post_save.connect(resourcebase_post_save, sender=Layer)
 signals.pre_delete.connect(pre_delete_layer, sender=Layer)
 signals.post_delete.connect(post_delete_layer, sender=Layer)
+signals.post_delete.connect(post_delete_layer_file, sender=LayerFile)

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -307,9 +307,7 @@
       </div>
     </div>
 
-    {% if GEOSERVER_BASE_URL %}
-      {% get_obj_perms request.user for resource.layer as "layer_perms" %}
-    {% endif %}
+    {% get_obj_perms request.user for resource.layer as "layer_perms" %}
 
     <li class="list-group-item">
       <a href="{% url "layer_metadata_detail" resource.typename %}">
@@ -348,6 +346,14 @@
                   <a class="btn btn-default btn-block btn-xs style-edit" data-dismiss="modal" href="#">{% trans "Edit" %}</a>
                   {% endif %}
                   <a class="btn btn-default btn-block btn-xs" href="{% url "layer_style_manage" resource.service_typename %}">{% trans "Manage" %}</a>
+                </div>
+                {% endif %}
+              {% elif OGC_SERVER.default.BACKEND == 'geonode.qgis_server' and not resource.service %}
+                {% if "change_layer_style" in layer_perms and preview == 'leaflet' %}
+                <div class="col-sm-3">
+                  <i class="fa fa-tint fa-3x"></i>
+                  <h4>{% trans "Styles" %}</h4>
+                  <a class="btn btn-default btn-block btn-xs style-edit" data-dismiss="modal" href="#">{% trans "Edit" %}</a>
                 </div>
                 {% endif %}
               {% endif %}

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -371,7 +371,7 @@
                 {% if "change_resourcebase" in perms_list and not resource.service %}
                 <a class="btn btn-default btn-block btn-xs" href="{% url "layer_replace" resource.service_typename %}">{% trans "Replace" %}</a>
                 {% endif %}
-                {% if resource.storeType == 'dataStore' and "change_layer_data" in layer_perms %}
+                {% if resource.storeType == 'dataStore' and "change_layer_data" in layer_perms and OGC_SERVER.default.BACKEND == 'geonode.geoserver' %}
                 <a class="btn btn-default btn-block btn-xs" href="{% url "new_map" %}?layer={{resource.service_typename}}">{% trans "Edit data" %}</a>
                 {% endif %}
                 {% if "delete_resourcebase" in perms_list %}

--- a/geonode/layers/templates/layers/layer_leaflet_map.html
+++ b/geonode/layers/templates/layers/layer_leaflet_map.html
@@ -231,40 +231,46 @@
         }
 
         {% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
-        $(".style-edit").on('click', function (event) {
-            $("#qgis-server-style-edit").modal('show');
-        });
+            {# expose map object to window #}
+            window.preview_map = map;
 
-        function edit_style_on_submit(event){
-            {# prevent form submit by default #}
-            var data = new FormData();
-            $.each($("#id_qml")[0].files, function(i, file){
-                data.append('qml', file);
-            });
-            var action = $(this).attr('action');
-            $.ajax({
-                url: action,
-                data: data,
-                cache: false,
-                contentType: false,
-                processData: false,
-                type: 'POST',
-                success: function(data){
-                    if(data){
-                        $("#qgis-server-style-edit .modal-body").html(data);
-                        $(document).ready(function() {
-                            $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
-                        });
+            {# Event handler for style editing #}
+            function edit_style_on_submit(event){
+                {# prevent form submit by default #}
+                var data = new FormData();
+                $.each($("#id_qml")[0].files, function(i, file){
+                    data.append('qml', file);
+                });
+                var action = $(this).attr('action');
+                $.ajax({
+                    url: action,
+                    data: data,
+                    cache: false,
+                    contentType: false,
+                    processData: false,
+                    type: 'POST',
+                    success: function(data){
+                        if(data){
+                            $("#qgis-server-style-edit .modal-body").html(data);
+                            $(document).ready(function() {
+                                $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
+                            });
+                        }
+                    },
+                    failure: function(data){
+                        alert('{% trans "Failed to change layer style." %}');
                     }
-                },
-                failure: function(data){
-                    alert('{% trans "Failed to change layer style." %}');
-                }
-            });
-            return false;
-        }
+                });
+                return false;
+            }
 
-        $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
+            {# Trigger dialog for Style edit #}
+            $(".style-edit").on('click', function (event) {
+                $("#qgis-server-style-edit").modal('show');
+            });
+
+            {# Attach form submit event #}
+            $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
         {% endif %}
   });
 
@@ -276,6 +282,19 @@
           map.fitBounds(bounds);
       }
 
+
+  {% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
+
+    function createMapThumbnail() {
+        {# Use map extent #}
+        var map = window.preview_map;
+        var bbox = map.getBounds().toBBoxString();
+        var data = {
+            'bbox': bbox
+        };
+        $.post('{% url "qgis_server:set-thumbnail" layername=resource.name %}', data);
+    }
+  {% endif %}
 </script>
 
 {% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}

--- a/geonode/layers/templates/layers/layer_leaflet_map.html
+++ b/geonode/layers/templates/layers/layer_leaflet_map.html
@@ -1,4 +1,5 @@
 {% load leaflet_tags %}
+{% load i18n %}
 
 {% leaflet_js %}
 {% leaflet_css %}
@@ -228,7 +229,45 @@
             //adjust info
             L.control.navbar().addTo(map);
         }
+
+        {% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
+        $(".style-edit").on('click', function (event) {
+            $("#qgis-server-style-edit").modal('show');
+        });
+
+        function edit_style_on_submit(event){
+            {# prevent form submit by default #}
+            var data = new FormData();
+            $.each($("#id_qml")[0].files, function(i, file){
+                data.append('qml', file);
+            });
+            var action = $(this).attr('action');
+            $.ajax({
+                url: action,
+                data: data,
+                cache: false,
+                contentType: false,
+                processData: false,
+                type: 'POST',
+                success: function(data){
+                    if(data){
+                        $("#qgis-server-style-edit .modal-body").html(data);
+                        $(document).ready(function() {
+                            $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
+                        });
+                    }
+                },
+                failure: function(data){
+                    alert('{% trans "Failed to change layer style." %}');
+                }
+            });
+            return false;
+        }
+
+        $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
+        {% endif %}
   });
+
   function zoom_to_box(map, bbox) {
           var bounds = [
               [bbox[1], bbox[0]],
@@ -238,3 +277,19 @@
       }
 
 </script>
+
+{% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
+    <div class="modal fade" id="qgis-server-style-edit" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title">{% trans "Upload QML Style" %}</h4>
+                </div>
+                <div class="modal-body">
+                    {% include "qgis_server/forms/qml_style.html" %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -45,7 +45,7 @@ from django.db.models import Q
 # Geonode functionality
 from geonode import GeoNodeException, geoserver, qgis_server
 from geonode.people.utils import get_valid_user
-from geonode.layers.models import Layer, UploadSession
+from geonode.layers.models import Layer, UploadSession, LayerFile
 from geonode.base.models import Link, SpatialRepresentationType, TopicCategory, Region, License, \
     ResourceBase
 from geonode.layers.models import shp_exts, csv_exts, vec_exts, cov_exts
@@ -810,3 +810,16 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
 
         if image is not None:
             instance.save_thumbnail(thumbnail_name, image=image)
+
+
+def delete_orphaned_layers():
+    """Delete orphaned layer files."""
+    layer_path = os.path.join(settings.MEDIA_ROOT, 'layers')
+    for filename in os.listdir(layer_path):
+        fn = os.path.join(layer_path, filename)
+        if LayerFile.objects.filter(file__icontains=filename).count() == 0:
+            print 'Removing orphan layer file %s' % fn
+            try:
+                os.remove(fn)
+            except OSError:
+                print 'Could not delete file %s' % fn

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -759,7 +759,7 @@ def layer_replace(request, layername, template='layers/layer_replace.html'):
                         try:
                             qgis_layer = QGISServerLayer.objects.get(
                                 layer=layer)
-                            qgis_layer.delete_qgis_layer()
+                            qgis_layer.delete()
                         except QGISServerLayer.DoesNotExist:
                             pass
 

--- a/geonode/qgis_server/context_processors.py
+++ b/geonode/qgis_server/context_processors.py
@@ -20,7 +20,9 @@
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
+
 from geonode.geoserver.helpers import ogc_server_settings
+from geonode.qgis_server.forms import QGISLayerStyleUploadForm
 
 
 def qgis_server_urls(request):
@@ -53,4 +55,5 @@ def qgis_server_urls(request):
                         'MOSAIC_ENABLED',
                         False),
     )
+    defaults['style_upload_form'] = QGISLayerStyleUploadForm()
     return defaults

--- a/geonode/qgis_server/forms.py
+++ b/geonode/qgis_server/forms.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+import os
+
+from django import forms
+from django.core.exceptions import ValidationError
+
+
+def _extension_validator(value):
+    __, ext = os.path.splitext(value.name)
+    if not ext == '.qml':
+        raise ValidationError('Only accept QML file.')
+
+
+class QGISLayerStyleUploadForm(forms.Form):
+
+    qml = forms.FileField(label='QML', validators=[_extension_validator])

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -19,6 +19,8 @@
 #########################################################################
 import logging
 import os
+
+import requests
 from requests import Request
 from urlparse import urljoin
 
@@ -225,3 +227,28 @@ def thumbnail_url(bbox, layers, qgis_project):
     }
     url = Request('GET', qgis_server_url, params=query_string).prepare().url
     return url
+
+
+def create_qgis_project(layer, qgis_layer=None):
+    """Create a new QGS Project for a given layer.
+
+    :param layer: Layer
+    :type layer: geonode.layers.models.Layer
+
+    :param qgis_layer: QGIS Layer model
+    :type qgis_layer: geonode.qgis_server.models.QGISServerLayer
+
+    """
+    qgis_server = settings.QGIS_SERVER_CONFIG['qgis_server_url']
+    if not qgis_layer:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    basename, _ = os.path.splitext(qgis_layer.base_layer_path)
+    query_string = {
+        'SERVICE': 'MAPCOMPOSITION',
+        'PROJECT': '%s.qgs' % basename,
+        'FILES': qgis_layer.base_layer_path,
+        'NAMES': layer.name,
+        'OVERWRITE': 'true',
+    }
+    response = requests.get(qgis_server, params=query_string)
+    return response

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -120,11 +120,15 @@ def tile_url(layer_name):
     return url
 
 
-def map_thumbnail_url(instance):
+def map_thumbnail_url(instance, bbox=None):
     """Construct QGIS Server Url to fetch remote map thumbnail.
 
     :param instance: Map object
     :type instance: geonode.maps.models.Map
+
+    :param bbox: Bounding box of thumbnail in 4 tuple format
+        [xmin,ymin,xmax,ymax]
+    :type bbox: list(float)
 
     :return: thumbnail url
     :rtype: str
@@ -139,16 +143,21 @@ def map_thumbnail_url(instance):
         logger.debug(msg)
         return None
 
-    # We get the extent of these layers.
-    bbox = [float(i) for i in instance.bbox_string.split(',')]
+    if not bbox:
+        # We get the extent of these layers.
+        bbox = [float(i) for i in instance.bbox_string.split(',')]
     return thumbnail_url(bbox, layers, qgis_project)
 
 
-def layer_thumbnail_url(instance):
+def layer_thumbnail_url(instance, bbox=None):
     """Construct QGIS Server Url to fetch remote layer thumbnail.
 
     :param instance: Layer object
     :type instance: geonode.layers.models.Layer
+
+    :param bbox: Bounding box of thumbnail in 4 tuple format
+        [xmin,ymin,xmax,ymax]
+    :type bbox: list(float)
 
     :return: Thumbnail URL.
     :rtype: str
@@ -164,12 +173,13 @@ def layer_thumbnail_url(instance):
     qgis_project = basename + '.qgs'
     layers = instance.name
 
-    # We get the extent of the layer.
-    x_min = instance.resourcebase_ptr.bbox_x0
-    x_max = instance.resourcebase_ptr.bbox_x1
-    y_min = instance.resourcebase_ptr.bbox_y0
-    y_max = instance.resourcebase_ptr.bbox_y1
-    bbox = [x_min, y_min, x_max, y_max]
+    if not bbox:
+        # We get the extent of the layer.
+        x_min = instance.resourcebase_ptr.bbox_x0
+        x_max = instance.resourcebase_ptr.bbox_x1
+        y_min = instance.resourcebase_ptr.bbox_y0
+        y_max = instance.resourcebase_ptr.bbox_y1
+        bbox = [x_min, y_min, x_max, y_max]
 
     return thumbnail_url(bbox, layers, qgis_project)
 

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -21,6 +21,7 @@ import logging
 import os
 
 import requests
+import shutil
 from requests import Request
 from urlparse import urljoin
 
@@ -239,7 +240,7 @@ def thumbnail_url(bbox, layers, qgis_project):
     return url
 
 
-def create_qgis_project(layer, qgis_layer=None):
+def create_qgis_project(layer, qgis_layer=None, overwrite=False):
     """Create a new QGS Project for a given layer.
 
     :param layer: Layer
@@ -248,17 +249,52 @@ def create_qgis_project(layer, qgis_layer=None):
     :param qgis_layer: QGIS Layer model
     :type qgis_layer: geonode.qgis_server.models.QGISServerLayer
 
+    :param overwrite: Flag to recreate QGIS Project if necessary
+    :type overwrite: bool
+
     """
     qgis_server = settings.QGIS_SERVER_CONFIG['qgis_server_url']
     if not qgis_layer:
         qgis_layer = QGISServerLayer.objects.get(layer=layer)
     basename, _ = os.path.splitext(qgis_layer.base_layer_path)
+
+    overwrite = str(overwrite).lower()
+
     query_string = {
         'SERVICE': 'MAPCOMPOSITION',
         'PROJECT': '%s.qgs' % basename,
         'FILES': qgis_layer.base_layer_path,
         'NAMES': layer.name,
-        'OVERWRITE': 'true',
+        'OVERWRITE': overwrite,
     }
     response = requests.get(qgis_server, params=query_string)
     return response
+
+
+def delete_orphaned_qgis_server_layers():
+    """Delete orphaned QGIS Server files."""
+    layer_path = settings.QGIS_SERVER_CONFIG['layer_directory']
+    for filename in os.listdir(layer_path):
+        basename, __ = os.path.splitext(filename)
+        fn = os.path.join(layer_path, filename)
+        if QGISServerLayer.objects.filter(
+                base_layer_path__icontains=basename).count() == 0:
+            print 'Removing orphan layer file %s' % fn
+            try:
+                os.remove(fn)
+            except OSError:
+                print 'Could not delete file %s' % fn
+
+
+def delete_orphaned_qgis_server_caches():
+    """Delete orphaned QGIS Server tile caches."""
+    tiles_path = settings.QGIS_SERVER_CONFIG['tiles_directory']
+    for basename in os.listdir(tiles_path):
+        path = os.path.join(tiles_path, basename)
+        if QGISServerLayer.objects.filter(
+                base_layer_path__icontains=basename).count() == 0:
+            print 'Removing orphan layer file %s' % path
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                print 'Could not delete file %s' % path

--- a/geonode/qgis_server/management/__init__.py
+++ b/geonode/qgis_server/management/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################

--- a/geonode/qgis_server/management/commands/__init__.py
+++ b/geonode/qgis_server/management/commands/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################

--- a/geonode/qgis_server/management/commands/delete_orphaned_qgis_server_layers.py
+++ b/geonode/qgis_server/management/commands/delete_orphaned_qgis_server_layers.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.core.management.base import BaseCommand
+
+from geonode.layers.utils import delete_orphaned_layers
+from geonode.qgis_server.helpers import delete_orphaned_qgis_server_layers, \
+    delete_orphaned_qgis_server_caches
+
+
+class Command(BaseCommand):
+    help = ("Delete orphaned QGIS Server layers.")
+
+    def handle(self, *args, **options):
+        delete_orphaned_layers()
+        delete_orphaned_qgis_server_layers()
+        delete_orphaned_qgis_server_caches()

--- a/geonode/qgis_server/management/commands/tests.py
+++ b/geonode/qgis_server/management/commands/tests.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+import os
+import urlparse
+from imghdr import what
+
+import gisdata
+from django.core.management import call_command
+from django.test import LiveServerTestCase
+from geonode.qgis_server.models import QGISServerLayer
+
+from geonode.layers.models import Layer
+
+
+class TestManagementCommands(LiveServerTestCase):
+
+    def setUp(self):
+        call_command('loaddata', 'people_data', verbosity=0)
+
+    def test_import_layers(self):
+        """Importlayers management command should properly overwrite."""
+        filename = os.path.join(
+            gisdata.GOOD_DATA,
+            'vector/san_andres_y_providencia_administrative.shp')
+        call_command('importlayers', filename, overwrite=True)
+
+        # Check that layer is created
+        self.assertEqual(Layer.objects.count(), 1)
+        layer = Layer.objects.first()
+        self.assertEqual(
+            layer.name, 'san_andres_y_providencia_administrative')
+
+        # Check that QGIS Project is created
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+        qgs_path = qgis_layer.qgis_project_path
+        self.assertTrue(os.path.exists(qgs_path))
+        qgis_project_modified_time = os.path.getmtime(qgs_path)
+
+        # Save all modified time of files
+        modified_time = {}
+        for f in qgis_layer.files:
+            modified_time[f] = os.path.getmtime(f)
+        layer_modified_time = {}
+        for f in layer.upload_session.layerfile_set.all():
+            layer_modified_time[f.file.path] = os.path.getmtime(
+                f.file.path)
+
+        # Check that no cache is generated yet
+        self.assertFalse(os.path.exists(qgis_layer.cache_path))
+
+        # Check that tiles link is created
+        tiles_link = layer.link_set.get(name='Tiles')
+        """:type: geonode.base.models.Link"""
+        self.assertEqual(tiles_link.extension, 'tiles')
+        tiles_url = urlparse.unquote(tiles_link.url)
+        tiles = {
+            'z': 7,
+            'x': 34,
+            'y': 59
+        }
+
+        # Try request a tile so a cache is generated
+        self.client.login(username='admin', password='admin')
+        self.client.get(tiles_url.format(**tiles))
+
+        # Check tiles cache generated
+        self.assertTrue(os.path.exists(qgis_layer.cache_path))
+        tiles_png = os.path.join(
+            qgis_layer.cache_path, str(tiles['z']), str(tiles['x']),
+            str(tiles['y']) + '.png')
+        self.assertTrue(os.path.exists(tiles_png))
+        self.assertEqual(what(tiles_png), 'png')
+
+        # Now, re-import the same file
+        call_command('importlayers', filename, overwrite=True)
+
+        # Check that it is still registered as the same layer
+        self.assertEqual(Layer.objects.count(), 1)
+        layer = Layer.objects.first()
+        self.assertEqual(
+            layer.name, 'san_andres_y_providencia_administrative')
+
+        # Check that QGIS Project is created and new
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+        qgs_path = qgis_layer.qgis_project_path
+        self.assertTrue(os.path.exists(qgs_path))
+        self.assertNotEqual(
+            qgis_project_modified_time, os.path.getmtime(qgs_path))
+
+        # Compare modified time and it should be different
+        for f in qgis_layer.files:
+            # for qgis_layer the filename will be the same (overwritten)
+            self.assertNotEqual(modified_time[f], os.path.getmtime(f))
+        for f in layer.upload_session.layerfile_set.all():
+            # for geonode layers, filename might not be the same, so compare
+            # extension instead
+            filepath = f.file.path
+            __, extension = os.path.splitext(filepath)
+            old_mtime = [
+                v for k, v in layer_modified_time.iteritems()
+                if k.endswith(extension)][0]
+            self.assertNotEqual(old_mtime, os.path.getmtime(filepath))
+
+        # New geonode layers might not be the same name, but in that case
+        # previous files should not exists
+        for f in layer.upload_session.layerfile_set.all():
+            filepath = f.file.path
+            if filepath not in layer_modified_time.iterkeys():
+                __, extension = os.path.splitext(filepath)
+                old_filepath = [
+                    k for k in layer_modified_time.iterkeys()
+                    if k.endswith(extension)][0]
+                self.assertFalse(os.path.exists(old_filepath))
+
+        # Tile caches should be deleted
+        self.assertFalse(os.path.exists(qgis_layer.cache_path))
+
+        # Cleanup
+        layer.delete()

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -70,7 +70,7 @@ class QGISServerLayer(models.Model):
         :rtype: list(str)
         """
         base_path = self.base_layer_path
-        base_name, _ = os.path.splitext(base_path)
+        base_name, __ = os.path.splitext(base_path)
         extensions_list = QGISServerLayer.accepted_format
 
         # QGIS can create a .aux.xml too
@@ -83,6 +83,13 @@ class QGISServerLayer(models.Model):
             if os.path.exists(file_path):
                 found_files.append(file_path)
         return found_files
+
+    @property
+    def qgis_project_path(self):
+        """Returned QGIS Project path related with this layer."""
+        base_path = self.base_layer_path
+        base_name, __ = os.path.splitext(base_path)
+        return base_name + '.qgs'
 
     @property
     def cache_path(self):

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -49,9 +49,9 @@ if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
 qgis_map_with_layers = Signal(providing_args=[])
 
 
-def qgis_server_layer_pre_delete(instance, sender, **kwargs):
+def qgis_server_layer_post_delete(instance, sender, **kwargs):
     """Removes the layer from Local Storage."""
-    logger.debug('QGIS Server Layer Pre Delete')
+    logger.debug('QGIS Server Layer Post Delete')
     instance.delete_qgis_layer()
 
 
@@ -209,8 +209,12 @@ def qgis_server_post_save(instance, sender, **kwargs):
             )
         )
 
+    # if layer has overwrite attribute, then it probably comes from
+    # importlayers management command and needs to be overwritten
+    overwrite = getattr(instance, 'overwrite', False)
+
     # Create the QGIS Project
-    response = create_qgis_project(instance, qgis_layer)
+    response = create_qgis_project(instance, qgis_layer, overwrite)
 
     logger.debug('Creating the QGIS Project : %s' % response.url)
     if response.content != 'OK':
@@ -265,7 +269,7 @@ def qgis_server_post_save(instance, sender, **kwargs):
 
     # Create thumbnail
     create_qgis_server_thumbnail.delay(
-        instance, overwrite=True)
+        instance, overwrite=overwrite)
 
     # Attributes
     set_attributes(instance)
@@ -286,6 +290,17 @@ def qgis_server_post_save(instance, sender, **kwargs):
             }
             update_xml(xml_file_path, new_values)
         except (TypeError, AttributeError):
+            pass
+
+    # Remove existing tile caches if overwrite
+    if overwrite:
+        tiles_directory = settings.QGIS_SERVER_CONFIG['tiles_directory']
+        basename, _ = os.path.splitext(qgis_layer.base_layer_path)
+        basename = os.path.basename(basename)
+        tiles_cache_path = os.path.join(tiles_directory, basename)
+        try:
+            shutil.rmtree(tiles_cache_path)
+        except:
             pass
 
 
@@ -377,7 +392,7 @@ if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
         qgis_server_post_save_map,
         dispatch_uid='Map-qgis_server_post_save_map',
         sender=Map)
-    signals.pre_delete.connect(
-        qgis_server_layer_pre_delete,
-        dispatch_uid='QGISServerLayer-qgis_server_layer_pre_delete',
+    signals.post_delete.connect(
+        qgis_server_layer_post_delete,
+        dispatch_uid='QGISServerLayer-qgis_server_layer_post_delete',
         sender=QGISServerLayer)

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -35,7 +35,7 @@ from geonode.base.models import Link
 from geonode.layers.models import Layer
 from geonode.maps.models import Map, MapLayer
 from geonode.qgis_server.gis_tools import set_attributes
-from geonode.qgis_server.helpers import tile_url
+from geonode.qgis_server.helpers import tile_url, create_qgis_project
 from geonode.qgis_server.models import QGISServerLayer
 from geonode.qgis_server.tasks.update import create_qgis_server_thumbnail
 from geonode.utils import check_ogc_backend
@@ -210,15 +210,7 @@ def qgis_server_post_save(instance, sender, **kwargs):
         )
 
     # Create the QGIS Project
-    qgis_server = settings.QGIS_SERVER_CONFIG['qgis_server_url']
-    basename, _ = os.path.splitext(qgis_layer.base_layer_path)
-    query_string = {
-        'SERVICE': 'MAPCOMPOSITION',
-        'PROJECT': '%s.qgs' % basename,
-        'FILES': qgis_layer.base_layer_path,
-        'NAMES': instance.name
-    }
-    response = requests.get(qgis_server, params=query_string)
+    response = create_qgis_project(instance, qgis_layer)
 
     logger.debug('Creating the QGIS Project : %s' % response.url)
     if response.content != 'OK':

--- a/geonode/qgis_server/tasks/update.py
+++ b/geonode/qgis_server/tasks/update.py
@@ -34,14 +34,31 @@ logger = logging.getLogger(__name__)
 @task(
     name='geonode.qgis_server.tasks.update.create_qgis_server_thumbnail',
     queue='update')
-def create_qgis_server_thumbnail(instance, overwrite=False):
+def create_qgis_server_thumbnail(instance, overwrite=False, bbox=None):
+    """Task to update thumbnails.
+
+    This task will formulate OGC url to generate thumbnail and then pass it
+    to geonode
+
+    :param instance: Resource instance, can be a layer or map
+    :type instance: Layer, Map
+
+    :param overwrite: set True to overwrite
+    :type overwrite: bool
+
+    :param bbox: Bounding box of thumbnail in 4 tuple format
+        [xmin,ymin,xmax,ymax]
+    :type bbox: list(float)
+
+    :return:
+    """
     thumbnail_remote_url = None
     try:
         # to make sure it is executed after the instance saved
         if isinstance(instance, Layer):
-            thumbnail_remote_url = layer_thumbnail_url(instance)
+            thumbnail_remote_url = layer_thumbnail_url(instance, bbox=bbox)
         elif isinstance(instance, Map):
-            thumbnail_remote_url = map_thumbnail_url(instance)
+            thumbnail_remote_url = map_thumbnail_url(instance, bbox=bbox)
         else:
             # instance type does not have associated thumbnail
             return True

--- a/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
+++ b/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
@@ -1,0 +1,22 @@
+
+{% load i18n %}
+{% load bootstrap_tags %}
+
+{% if success %}
+<script type="text/javascript">
+    window.location.reload()
+</script>
+<p>
+{% trans "Layer Style changed. Redirecting to apply changes..." %}
+</p>
+<p>
+{% trans "You may also use browser reload." %}
+</p>
+{% else %}
+<form id="qgis-server-style-edit-form" method="post" action="{% url "qgis_server:update-qml" layername=resource.name %}" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ style_upload_form|as_bootstrap }}
+    <a href="{% url "qgis_server:download-qml" layername=resource.name %}" class="btn btn-default">{% trans "Download Current Style" %}</a>
+    <button type="submit" class="btn btn-primary">{% trans "Upload" %}</button>
+</form>
+{% endif %}

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -23,6 +23,7 @@ import json
 import os
 import urlparse
 import zipfile
+from imghdr import what
 
 import gisdata
 from django.conf import settings
@@ -206,6 +207,7 @@ class ThumbnailGenerationTest(LiveServerTestCase):
 
         # Check thumbnail created
         self.assertTrue(os.path.exists(thumbnail_path))
+        self.assertEqual(what(thumbnail_path), 'png')
 
         # Check that now we have thumbnail
         self.assertTrue(layer.has_thumbnail())
@@ -343,6 +345,7 @@ class ThumbnailGenerationTest(LiveServerTestCase):
 
         # Check thumbnail created
         self.assertTrue(os.path.exists(thumbnail_path))
+        self.assertEqual(what(thumbnail_path), 'png')
 
         # Check that now we have thumbnail
         self.assertTrue(map.has_thumbnail())

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -19,6 +19,7 @@
 #########################################################################
 
 import StringIO
+import json
 import os
 import urlparse
 import zipfile
@@ -33,6 +34,7 @@ from django.test import LiveServerTestCase, TestCase
 from geonode import qgis_server
 from geonode.decorators import on_ogc_backend
 from geonode.layers.utils import file_upload
+from geonode.maps.models import Map
 
 
 class DefaultViewsTest(TestCase):
@@ -183,8 +185,7 @@ class ThumbnailGenerationTest(LiveServerTestCase):
         # check that we have remote thumbnail
         remote_thumbnail_link = layer.link_set.get(
             name__icontains='remote thumbnail')
-        self.assertTrue(
-            remote_thumbnail_link.url != settings.MISSING_THUMBNAIL)
+        self.assertTrue(remote_thumbnail_link.url)
 
         # thumbnail won't generate because remote thumbnail uses public
         # address
@@ -219,3 +220,145 @@ class ThumbnailGenerationTest(LiveServerTestCase):
         link_names = ['remote thumbnail', 'thumbnail']
         for link in thumbnail_links:
             self.assertIn(link.name.lower(), link_names)
+
+        # cleanup
+        layer.delete()
+
+    @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
+    def test_map_thumbnail(self):
+        """Creating map will create thumbnail."""
+        filename = os.path.join(
+            gisdata.GOOD_DATA, 'raster/relief_san_andres.tif')
+        layer1 = file_upload(filename)
+
+        filename = os.path.join(
+            gisdata.GOOD_DATA,
+            'vector/san_andres_y_providencia_administrative.shp')
+        layer2 = file_upload(filename)
+        """:type: geonode.layers.models.Layer"""
+
+        # construct json request for new map
+        json_payload = {
+            "sources": {
+                "source_OpenMapSurfer Roads": {
+                    "url": "http://korona.geog.uni-heidelberg.de/tiles"
+                           "/roads/x={x}&y={y}&z={z}"
+                },
+                "source_OpenStreetMap": {
+                    "url": "http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+                },
+                "source_san_andres_y_providencia_administrative": {
+                    "url": "http://geonode.dev/qgis-server/tiles"
+                           "/san_andres_y_providencia_administrative/"
+                           "{z}/{x}/{y}.png"
+                },
+                "source_relief_san_andres": {
+                    "url": "http://geonode.dev/qgis-server/tiles"
+                           "/relief_san_andres/{z}/{x}/{y}.png"
+                }
+            },
+            "about": {
+                "title": "San Andreas",
+                "abstract": "San Andreas sample map"
+            },
+            "map": {
+                "center": [12.91890657418042, -81.298828125],
+                "zoom": 6,
+                "projection": "",
+                "layers": [
+                    {
+                        "name": "OpenMapSurfer_Roads",
+                        "title": "OpenMapSurfer Roads",
+                        "visibility": True,
+                        "url": "http://korona.geog.uni-heidelberg.de/tiles/"
+                               "roads/x={x}&y={y}&z={z}",
+                        "group": "background",
+                        "source": "source_OpenMapSurfer Roads"
+                    },
+                    {
+                        "name": "osm",
+                        "title": "OpenStreetMap",
+                        "visibility": False,
+                        "url": "http://{s}.tile.osm.org/{z}/{x}/{y}.png",
+                        "group": "background",
+                        "source": "source_OpenStreetMap"
+                    },
+                    {
+                        "name": "geonode:"
+                                "san_andres_y_providencia_administrative",
+                        "title": "san_andres_y_providencia_administrative",
+                        "visibility": True,
+                        "url": "http://geonode.dev/qgis-server/tiles"
+                               "/san_andres_y_providencia_administrative/"
+                               "{z}/{x}/{y}.png",
+                        "source": "source_"
+                                  "san_andres_y_providencia_administrative"
+                    },
+                    {
+                        "name": "geonode:relief_san_andres",
+                        "title": "relief_san_andres",
+                        "visibility": True,
+                        "url": "http://geonode.dev/qgis-server/tiles"
+                               "/relief_san_andres/{z}/{x}/{y}.png",
+                        "source": "source_relief_san_andres"
+                    }
+                ]
+            }
+        }
+
+        self.client.login(username='admin', password='admin')
+
+        response = self.client.post(
+            reverse('new_map_json'),
+            json.dumps(json_payload),
+            content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+
+        map_id = json.loads(response.content).get('id')
+
+        map = Map.objects.get(id=map_id)
+
+        # check that we have remote thumbnail
+        remote_thumbnail_link = map.link_set.get(
+            name__icontains='remote thumbnail')
+        self.assertTrue(remote_thumbnail_link.url)
+
+        # thumbnail won't generate because remote thumbnail uses public
+        # address
+
+        remote_thumbnail_url = remote_thumbnail_link.url
+
+        # Replace url's basename, we want to access it using django client
+        parse_result = urlparse.urlsplit(remote_thumbnail_url)
+        remote_thumbnail_url = urlparse.urlunsplit(
+            ('', '', parse_result.path, parse_result.query, ''))
+
+        response = self.client.get(remote_thumbnail_url)
+
+        thumbnail_dir = os.path.join(settings.MEDIA_ROOT, 'thumbs')
+        thumbnail_path = os.path.join(thumbnail_dir, 'map-thumb.png')
+
+        map.save_thumbnail(thumbnail_path, response.content)
+
+        # Check thumbnail created
+        self.assertTrue(os.path.exists(thumbnail_path))
+
+        # Check that now we have thumbnail
+        self.assertTrue(map.has_thumbnail())
+
+        missing_thumbnail_url = staticfiles.static(settings.MISSING_THUMBNAIL)
+
+        self.assertTrue(map.get_thumbnail_url() != missing_thumbnail_url)
+
+        thumbnail_links = map.link_set.filter(name__icontains='thumbnail')
+        self.assertTrue(len(thumbnail_links) > 0)
+
+        link_names = ['remote thumbnail', 'thumbnail']
+        for link in thumbnail_links:
+            self.assertIn(link.name.lower(), link_names)
+
+        # cleanup
+        map.delete()
+        layer1.delete()
+        layer2.delete()

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -30,7 +30,7 @@ from geonode.qgis_server.views import (
     qgis_server_pdf,
     qgis_server_map_print,
     geotiff,
-    qml_style)
+    qml_style, set_thumbnail)
 
 
 urlpatterns = patterns(
@@ -106,5 +106,10 @@ urlpatterns = patterns(
         r'^style/(?P<layername>[^/]*)$',
         qml_style,
         name='download-qml'
+    ),
+    url(
+        r'^thumbnail/set/(?P<layername>[^/]*)$',
+        set_thumbnail,
+        name='set-thumbnail'
     ),
 )

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -30,7 +30,7 @@ from geonode.qgis_server.views import (
     qgis_server_pdf,
     qgis_server_map_print,
     geotiff,
-)
+    qml_style)
 
 
 urlpatterns = patterns(
@@ -96,5 +96,15 @@ urlpatterns = patterns(
         r'^map/print$',
         qgis_server_map_print,
         name='map-print'
+    ),
+    url(
+        r'^style/(?P<layername>[^/]*)/edit$',
+        qml_style,
+        name='update-qml'
+    ),
+    url(
+        r'^style/(?P<layername>[^/]*)$',
+        qml_style,
+        name='download-qml'
     ),
 )

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -32,13 +32,16 @@ from django.contrib.gis.gdal import SpatialReference, CoordTransform
 from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404
+from django.http.response import HttpResponseBadRequest, \
+    HttpResponseServerError, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils.translation import ugettext as _
 
 from geonode.layers.models import Layer
+from geonode.qgis_server.forms import QGISLayerStyleUploadForm
 from geonode.qgis_server.gis_tools import num2deg
-from geonode.qgis_server.helpers import tile_url
+from geonode.qgis_server.helpers import tile_url, create_qgis_project
 from geonode.qgis_server.models import QGISServerLayer
 
 logger = logging.getLogger('geonode.qgis_server.views')
@@ -422,3 +425,95 @@ def qgis_server_map_print(request):
         print '--------'
     return HttpResponse(
         json.dumps(temp), content_type="application/json")
+
+
+def qml_style(request, layername=None):
+    """Update/Retrieve QML style of a given QGIS Layer.
+
+    :param layername: The layer name in Geonode.
+    :type layername: basestring
+    :return:
+    """
+    layer = get_object_or_404(Layer, name=layername)
+    if request.method == 'GET':
+        try:
+
+            base_file_path, __ = layer.get_base_file()
+            base_file_path, __ = os.path.splitext(base_file_path.file.path)
+            qml_path = '{path}.qml'.format(path=base_file_path)
+
+            response = HttpResponse(
+                open(qml_path), content_type="application/xml")
+            # ..and correct content-disposition
+            response['Content-Disposition'] = (
+                'attachment; filename={filename}'.format(
+                    filename=os.path.basename(qml_path)))
+            return response
+        except:
+            return HttpResponseServerError()
+    elif request.method == 'POST':
+
+        form = QGISLayerStyleUploadForm(request.POST, request.FILES)
+
+        if not form.is_valid():
+            return TemplateResponse(
+                request,
+                'qgis_server/forms/qml_style.html',
+                {
+                    'resource': layer,
+                    'style_upload_form': form
+                },
+                status=200).render()
+
+        try:
+            uploaded_qml = request.FILES['qml']
+
+            # update qml in uploaded media folder
+            base_file_path, __ = layer.get_base_file()
+            file_name, __ = os.path.splitext(base_file_path.file.path)
+            qml_path = '{file_name}.qml'.format(file_name=file_name)
+
+            content = uploaded_qml.read()
+
+            with open(qml_path, mode='w') as f:
+                f.write(content)
+
+            # update qml in QGIS Layer folder
+            QGIS_layer_directory = settings.QGIS_SERVER_CONFIG['layer_directory']
+            base_file_path = os.path.basename(base_file_path.file.path)
+            file_name, __ = os.path.splitext(base_file_path)
+            qml_path = '{file_name}.qml'.format(file_name=file_name)
+            qml_path = os.path.join(QGIS_layer_directory, qml_path)
+
+            with open(qml_path, mode='w') as f:
+                f.write(content)
+
+            # update QGIS Project files
+            response = create_qgis_project(layer)
+            if not response.content == 'OK':
+                return HttpResponseServerError()
+
+            # Because we update a style, we need to recache
+            QGIS_tiles_directory = settings.QGIS_SERVER_CONFIG['tiles_directory']
+            qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
+            basename, _ = os.path.splitext(qgis_layer.base_layer_path)
+            basename = os.path.basename(basename)
+
+            layer_tiles_path = os.path.join(QGIS_tiles_directory, basename)
+
+            shutil.rmtree(layer_tiles_path)
+
+            return TemplateResponse(
+                request,
+                'qgis_server/forms/qml_style.html',
+                {
+                    'resource': layer,
+                    'style_upload_form': form,
+                    'success': True
+                },
+                status=200).render()
+
+        except:
+            return HttpResponseServerError()
+
+    return HttpResponseBadRequest()

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -32,8 +32,9 @@ from django.contrib.gis.gdal import SpatialReference, CoordTransform
 from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404
-from django.http.response import HttpResponseBadRequest, \
-    HttpResponseServerError, HttpResponseRedirect
+from django.http.response import (
+    HttpResponseBadRequest,
+    HttpResponseServerError)
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils.translation import ugettext as _
@@ -43,6 +44,7 @@ from geonode.qgis_server.forms import QGISLayerStyleUploadForm
 from geonode.qgis_server.gis_tools import num2deg
 from geonode.qgis_server.helpers import tile_url, create_qgis_project
 from geonode.qgis_server.models import QGISServerLayer
+from geonode.qgis_server.tasks.update import create_qgis_server_thumbnail
 
 logger = logging.getLogger('geonode.qgis_server.views')
 
@@ -340,7 +342,8 @@ def qgis_server_request(request):
 
     # As we have one project per layer, we add the MAP path if the request is
     # specific for one layer.
-    if params.get('LAYERS') or params.get('TYPENAME'):
+    map_param = params.get('MAP')
+    if not map_param and (params.get('LAYERS') or params.get('TYPENAME')):
         # LAYERS is for WMS, TYPENAME for WFS
         layer_name = params.get('LAYERS') or params.get('TYPENAME')
 
@@ -427,7 +430,7 @@ def qgis_server_map_print(request):
         json.dumps(temp), content_type="application/json")
 
 
-def qml_style(request, layername=None):
+def qml_style(request, layername):
     """Update/Retrieve QML style of a given QGIS Layer.
 
     :param layername: The layer name in Geonode.
@@ -452,6 +455,11 @@ def qml_style(request, layername=None):
         except:
             return HttpResponseServerError()
     elif request.method == 'POST':
+
+        # For people who uses API request
+        if not request.user.has_perm(
+                'change_resourcebase', layer.get_self_resource()):
+            return HttpResponse(status=401)
 
         form = QGISLayerStyleUploadForm(request.POST, request.FILES)
 
@@ -517,3 +525,37 @@ def qml_style(request, layername=None):
             return HttpResponseServerError()
 
     return HttpResponseBadRequest()
+
+
+def set_thumbnail(request, layername):
+    """Update thumbnail based on map extent
+
+    :param layername: The layer name in Geonode.
+    :type layername: basestring
+    :return:
+    """
+    if request.method != 'POST':
+        return HttpResponseBadRequest()
+
+    try:
+        layer = get_object_or_404(Layer, name=layername)
+
+        # For people who uses API request
+        if not request.user.has_perm(
+                'change_resourcebase', layer.get_self_resource()):
+            return HttpResponse(status=401)
+
+        # extract bbox
+        bbox_string = request.POST['bbox']
+        # BBox should be in the format: [xmin,ymin,xmax,ymax]
+        bbox = bbox_string.split(',')
+        bbox = [float(s) for s in bbox]
+
+        create_qgis_server_thumbnail.delay(layer, overwrite=True, bbox=bbox)
+        retval = {
+            'success': True
+        }
+        return HttpResponse(
+            json.dumps(retval), content_type="application/json")
+    except:
+        return HttpResponseServerError()

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -509,7 +509,10 @@ def qml_style(request, layername):
 
             layer_tiles_path = os.path.join(QGIS_tiles_directory, basename)
 
-            shutil.rmtree(layer_tiles_path)
+            try:
+                shutil.rmtree(layer_tiles_path)
+            except:
+                pass
 
             return TemplateResponse(
                 request,


### PR DESCRIPTION
- Refactor additional fields in Layers api. Will fix #281 
- Edit Layer Styles interaction. For #206 
- Edit Layer > Set thumbnails functionality. For #206 
- Handled #282 . Overwrite related thumbnails and QGIS Server files, however still doesn't deal with orphaned files automatically.