### PR TITLE
Hide QML Style download when not exists.

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -29,6 +29,7 @@ import decimal
 import re
 
 from django.contrib.gis.geos import GEOSGeometry
+from django.template.response import TemplateResponse
 from requests import Request
 
 from guardian.shortcuts import get_perms
@@ -374,7 +375,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
     if settings.SOCIAL_ORIGINS:
         context_dict["social_links"] = build_social_links(request, layer)
 
-    return render_to_response(template, RequestContext(request, context_dict))
+    return TemplateResponse(
+        request, template, RequestContext(request, context_dict))
 
 
 def layer_feature_catalogue(request, layername, template='../../catalogue/templates/catalogue/feature_catalogue.xml'):

--- a/geonode/qgis_server/middleware.py
+++ b/geonode/qgis_server/middleware.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+
+class QGISServerLayerMiddleware(object):
+
+    def process_template_response(self, request, response):
+        """Middleware to add more context for QGIS Server backend app.
+
+        :type request: django.http.request.HttpRequest
+        :type response: django.template.response.TemplateResponse
+        """
+
+        template_name = response.template_name
+        if template_name == 'layers/layer_detail.html':
+            self.layer_detail(request, response)
+
+        return response
+
+    def layer_detail(self, request, response):
+        """Provide more context for layer_detail view
+
+        :type request: django.http.request.HttpRequest
+        :type response: django.template.response.TemplateResponse
+        """
+        context = response.context_data
+
+        if 'resource' in context:
+            # provides context for QML Style
+            layer = context['resource']
+            """:type: geonode.layers.models.Layer"""
+            use_qml_style = layer.upload_session.layerfile_set.filter(
+                name='qml').count() > 0
+
+            context['use_qml_style'] = use_qml_style

--- a/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
+++ b/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
@@ -16,7 +16,9 @@
 <form id="qgis-server-style-edit-form" method="post" action="{% url "qgis_server:update-qml" layername=resource.name %}" enctype="multipart/form-data">
     {% csrf_token %}
     {{ style_upload_form|as_bootstrap }}
-    <a href="{% url "qgis_server:download-qml" layername=resource.name %}" class="btn btn-default">{% trans "Download Current Style" %}</a>
+    {% if use_qml_style %}
+        <a href="{% url "qgis_server:download-qml" layername=resource.name %}" class="btn btn-default">{% trans "Download Current Style" %}</a>
+    {% endif %}
     <button type="submit" class="btn btn-primary">{% trans "Upload" %}</button>
 </form>
 {% endif %}


### PR DESCRIPTION
Address remaining issue of #284 

Use middleware to apply more context.
Useful to avoid having edited geonode layers views in the future for qgis-server backend app.