### PR TITLE
Add style management for QGIS Server backend.

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -516,9 +516,11 @@ class QGISStyleResource(Resource):
         kwargs = {}
 
         if isinstance(bundle_or_obj, Bundle):
-            kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj.obj, self._meta.detail_uri_name)
+            kwargs[self._meta.detail_uri_name] = getattr(
+                bundle_or_obj.obj, self._meta.detail_uri_name)
         else:
-            kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj, self._meta.detail_uri_name)
+            kwargs[self._meta.detail_uri_name] = getattr(
+                bundle_or_obj, self._meta.detail_uri_name)
 
         return kwargs
 

--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -20,7 +20,6 @@
 
 import json
 import time
-import urlparse
 
 from django.conf.urls import url
 from django.contrib.auth import get_user_model
@@ -35,7 +34,6 @@ from guardian.shortcuts import get_objects_for_user
 from tastypie.authorization import Authorization
 from tastypie.bundle import Bundle
 
-from geonode import geoserver, qgis_server
 from geonode.base.models import ResourceBase
 from geonode.base.models import TopicCategory
 from geonode.base.models import Region
@@ -53,8 +51,6 @@ from tastypie import fields
 from tastypie.resources import ModelResource, Resource
 from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.utils import trailing_slash
-
-from geonode.utils import check_ogc_backend
 
 FILTER_TYPES = {
     'layer': Layer,

--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -20,6 +20,7 @@
 
 import json
 import time
+import urlparse
 
 from django.conf.urls import url
 from django.contrib.auth import get_user_model
@@ -31,14 +32,17 @@ from django.utils.translation import get_language
 
 from avatar.templatetags.avatar_tags import avatar_url
 from guardian.shortcuts import get_objects_for_user
+from tastypie.authorization import Authorization
+from tastypie.bundle import Bundle
 
+from geonode import geoserver, qgis_server
 from geonode.base.models import ResourceBase
 from geonode.base.models import TopicCategory
 from geonode.base.models import Region
 from geonode.base.models import HierarchicalKeyword
 from geonode.base.models import ThesaurusKeywordLabel
 
-from geonode.layers.models import Layer
+from geonode.layers.models import Layer, Style, LayerFile
 from geonode.maps.models import Map
 from geonode.documents.models import Document
 from geonode.groups.models import GroupProfile, GroupCategory
@@ -46,10 +50,11 @@ from geonode.groups.models import GroupProfile, GroupCategory
 from django.core.serializers.json import DjangoJSONEncoder
 from tastypie.serializers import Serializer
 from tastypie import fields
-from tastypie.resources import ModelResource
+from tastypie.resources import ModelResource, Resource
 from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.utils import trailing_slash
 
+from geonode.utils import check_ogc_backend
 
 FILTER_TYPES = {
     'layer': Layer,
@@ -426,3 +431,146 @@ class OwnersResource(TypeFilteredResource):
             'username': ALL,
         }
         serializer = CountJSONSerializer()
+
+
+class GeoserverStyleResource(ModelResource):
+    """Styles api for Geoserver backend."""
+
+    class Meta:
+        queryset = Style.objects.all()
+        resource_name = 'styles'
+        allowed_methods = ['get', 'post', 'put']
+        ordering = ['layername']
+
+
+class QGISStyleObject(object):
+
+    def __init__(self, style_id=None, name=None, layer=None,
+                 style_file=None, style_type='qml', style_url=None):
+        # File name of QML style file
+        self.name = name
+        # Related layers
+        if layer and len(layer) > 0:
+            self.layer = layer[0]
+        # File object of the style
+        self.file = style_file
+        # LayerFile id of QML style in upload session
+        self.id = style_id
+        # Extension type of this style
+        # Currently only for qml
+        self.type = style_type
+        # Url of downloadable QML Style
+        self.url = style_url
+
+
+class QGISStyleResource(Resource):
+    """Styles api for QGIS Server backend."""
+
+    name = fields.CharField(attribute='name')
+    layer = fields.ForeignKey(
+        'geonode.api.resourcebase_api.LayerResource',
+        attribute='layer')
+    id = fields.IntegerField(attribute='id')
+    type = fields.CharField(attribute='type')
+    url = fields.CharField(attribute='url', null=True)
+    file = fields.FileField(attribute='file')
+
+    class Meta:
+        resource_name = 'styles'
+        detail_uri_name = 'id'
+        object_class = QGISStyleObject
+        authorization = Authorization()
+
+    def _build_style_url(self, layerfile):
+        """Build downloadable url for QML Style.
+
+        :param layerfile: LayerFile object
+        :type layerfile: geonode.layers.models.LayerFile
+
+        :return: url
+        """
+        try:
+            layer = Layer.objects.get(upload_session=layerfile.upload_session)
+            layername = layer.name
+            style_url = reverse(
+                'qgis_server:download-qml',
+                kwargs={'layername': layername})
+        except Layer.DoesNotExist:
+            # There exists a stale layerfile
+            return None
+        return style_url
+
+    def _generate_result(self, layerfiles):
+        results = [
+            QGISStyleObject(
+                layer=lf.upload_session.layer_set.all(),
+                style_id=lf.id,
+                name=lf.file.name,
+                style_file=lf.file,
+                style_url=self._build_style_url(lf)) for lf in layerfiles
+        ]
+        results = [r for r in results if r.url]
+        return results
+
+    def detail_uri_kwargs(self, bundle_or_obj):
+        kwargs = {}
+
+        if isinstance(bundle_or_obj, Bundle):
+            kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj.obj, self._meta.detail_uri_name)
+        else:
+            kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj, self._meta.detail_uri_name)
+
+        return kwargs
+
+    def obj_get_list(self, bundle, **kwargs):
+        styles = []
+        if 'layername' in kwargs:
+            layername = kwargs.pop('layername')
+            layer = Layer.objects.get(name=layername)
+            styles = layer.upload_session.layerfile_set.filter(name='qml')
+        if not kwargs.items():
+            styles = LayerFile.objects.filter(name='qml')
+        return self._generate_result(styles)
+
+    def obj_get(self, bundle, **kwargs):
+        styles = []
+        if self._meta.detail_uri_name in kwargs:
+            style_id = kwargs.pop(self._meta.detail_uri_name)
+            styles = LayerFile.objects.filter(id=style_id)
+        results = self._generate_result(styles)
+        return results[0]
+
+    def obj_create(self, bundle, **kwargs):
+        bundle.obj = QGISStyleObject()
+        bundle = self.full_hydrate(bundle)
+        return bundle
+
+    def obj_update(self, bundle, **kwargs):
+        return self.obj_create(bundle, **kwargs)
+
+    def obj_delete_list(self, bundle, **kwargs):
+        bucket = self._bucket()
+
+        for key in bucket.get_keys():
+            obj = bucket.get(key)
+            obj.delete()
+
+    def obj_delete(self, bundle, **kwargs):
+        bucket = self._bucket()
+        obj = bucket.get(kwargs['pk'])
+        obj.delete()
+
+    def deserialize(self, request, data, format=None):
+        if not format:
+            format = request.Meta.get('CONTENT_TYPE', 'application/json')
+        if format == 'application/x-www-form-urlencoded':
+            return request.POST
+        if format.startswith('multipart'):
+            data = request.POST.copy()
+            data.update(request.FILES)
+            return data
+        return super(QGISStyleResource, self).deserialize(
+            request, data, format)
+
+    def rollback(self, bundles):
+        pass

--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -608,6 +608,7 @@ class LayerResource(CommonModelApi):
         if settings.RESOURCE_PUBLISHING:
             queryset = queryset.filter(is_published=True)
         resource_name = 'layers'
+        detail_uri_name = 'id'
         excludes = ['csw_anytext', 'metadata_xml']
 
 

--- a/geonode/api/urls.py
+++ b/geonode/api/urls.py
@@ -20,6 +20,9 @@
 
 from tastypie.api import Api
 
+from geonode import qgis_server
+from geonode.api.api import QGISStyleResource
+from geonode.utils import check_ogc_backend
 from .api import TagResource, TopicCategoryResource, ProfileResource, \
     GroupResource, RegionResource, OwnersResource, ThesaurusKeywordResource, \
     GroupCategoryResource
@@ -41,3 +44,6 @@ api.register(FeaturedResourceBaseResource())
 api.register(OwnersResource())
 api.register(ThesaurusKeywordResource())
 api.register(GroupCategoryResource())
+
+if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+    api.register(QGISStyleResource())

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -485,19 +485,35 @@
       <h4>{% trans "Styles" %}</h4>
        <p>{% trans "The following styles are associated with this layer. Choose a style to view it in the preview map." %}</p>
        <ul class="list-unstyled">
-        {% for style in resource.styles.all %}
-        <li>
-          {% if resource.default_style == style %}
-          <input type="radio" checked name="style" id="{{ style.name }}" value="{{ style.title }}"/>
-          (default style)
-          {% else %}
-          <input type="radio" name="style" id="{{ style.name }}" value="{{ style.title }}"/>
-          {% endif %}
-          <a href="{{ GEOSERVER_BASE_URL }}{{ style.absolute_url }}" >{{ style.sld_title }}</a>
-        </li>
-        {% empty %}
-        <li>{% trans "No styles associated with this layer" %}</li>
-        {% endfor %}
+        {% if OGC_SERVER.default.BACKEND == 'geonode.geoserver' %}
+            {% for style in resource.styles.all %}
+            <li>
+              {% if resource.default_style == style %}
+              <input type="radio" checked name="style" id="{{ style.name }}" value="{{ style.title }}"/>
+              (default style)
+              {% else %}
+              <input type="radio" name="style" id="{{ style.name }}" value="{{ style.title }}"/>
+              {% endif %}
+              <a href="{{ GEOSERVER_BASE_URL }}{{ style.absolute_url }}" >{{ style.sld_title }}</a>
+            </li>
+            {% empty %}
+            <li>{% trans "No styles associated with this layer" %}</li>
+            {% endfor %}
+        {% elif OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
+            {% for style in resource.qgis_layer.styles.all %}
+            <li>
+              {% if resource.qgis_layer.default_style == style %}
+              <input type="radio" checked name="style" id="{{ style.name }}" value="{{ style.title }}"/>
+              (default style)
+              {% else %}
+              <input type="radio" name="style" id="{{ style.name }}" value="{{ style.title }}"/>
+              {% endif %}
+              <a href="{{ style.style_url }}" >{{ style.title }}</a>
+            </li>
+            {% empty %}
+            <li>{% trans "No styles associated with this layer" %}</li>
+            {% endfor %}
+        {% endif %}
       </ul>
     </li>
     {% endif %}

--- a/geonode/layers/templates/layers/layer_leaflet_map.html
+++ b/geonode/layers/templates/layers/layer_leaflet_map.html
@@ -233,36 +233,7 @@
         {% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
             {# expose map object to window #}
             window.preview_map = map;
-
-            {# Event handler for style editing #}
-            function edit_style_on_submit(event){
-                {# prevent form submit by default #}
-                var data = new FormData();
-                $.each($("#id_qml")[0].files, function(i, file){
-                    data.append('qml', file);
-                });
-                var action = $(this).attr('action');
-                $.ajax({
-                    url: action,
-                    data: data,
-                    cache: false,
-                    contentType: false,
-                    processData: false,
-                    type: 'POST',
-                    success: function(data){
-                        if(data){
-                            $("#qgis-server-style-edit .modal-body").html(data);
-                            $(document).ready(function() {
-                                $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
-                            });
-                        }
-                    },
-                    failure: function(data){
-                        alert('{% trans "Failed to change layer style." %}');
-                    }
-                });
-                return false;
-            }
+            window.tile_layer = tile_layer;
 
             {# Trigger dialog for Style edit #}
             $(".style-edit").on('click', function (event) {
@@ -270,7 +241,28 @@
             });
 
             {# Attach form submit event #}
-            $("#qgis-server-style-edit-form").on('submit', edit_style_on_submit);
+            $("#qgis-server-style-add-form").on('submit', edit_style_on_submit);
+
+            {# Attach handler for style change #}
+            $("input[name='style']").on('change', function(event){
+                var $input = $(this);
+                if($input.prop('checked') == true){
+                    {# Tile url change #}
+                    var url;
+                    {% if resource.get_tiles_url %}
+                        url = '{% url "qgis_server:tile" layername=resource.name style='style_name' %}';
+                        url = url.replace('style_name', $input.attr('id'));
+                        url = decodeURIComponent(url);
+                        tile_layer.setUrl(url);
+                    {% endif %}
+
+                    {# Legend icon change #}
+                    url = '{% url "qgis_server:legend" layername=resource.name style='style_name' %}';
+                    url = url.replace('style_name', $input.attr('id'));
+                    url = decodeURIComponent(url);
+                    $("#legend_icon").attr('src', url);
+                }
+            });
         {% endif %}
   });
 
@@ -294,10 +286,45 @@
         };
         $.post('{% url "qgis_server:set-thumbnail" layername=resource.name %}', data);
     }
+
+    {# Event handler for style editing #}
+    function edit_style_on_submit(event){
+        {# prevent form submit by default #}
+        var data = new FormData();
+        $.each($("#id_qml")[0].files, function(i, file){
+            data.append('qml', file);
+        });
+        data.append('name', $("#id_name").val());
+        data.append('title', $("#id_title").val());
+        var action = $(this).attr('action');
+        $.ajax({
+            url: action,
+            data: data,
+            cache: false,
+            contentType: false,
+            processData: false,
+            type: 'POST',
+            success: function(data){
+                if(data){
+                    $("#qgis-server-style-edit .modal-body").html(data);
+                    $(document).ready(function() {
+                        $("#qgis-server-style-add-form").on('submit', edit_style_on_submit);
+                    });
+                }
+            }
+        });
+        return false;
+    }
   {% endif %}
 </script>
 
 {% if OGC_SERVER.default.BACKEND == 'geonode.qgis_server' %}
+    <style>
+        #qgis-server-style-edit .modal-body{
+            overflow-y: scroll;
+            max-height: 600px;
+        }
+    </style>
     <div class="modal fade" id="qgis-server-style-edit" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -54,7 +54,7 @@ from django.forms.util import ErrorList
 
 from geonode.tasks.deletion import delete_layer
 from geonode.services.models import Service
-from geonode.layers.forms import LayerForm, LayerUploadForm, NewLayerUploadForm, LayerAttributeForm
+from geonode.layers.forms import LayerForm, NewLayerUploadForm, LayerAttributeForm
 from geonode.base.forms import CategoryForm, TKeywordForm
 from geonode.layers.models import Layer, Attribute, UploadSession
 from geonode.base.enumerations import CHARSETS
@@ -751,7 +751,7 @@ def layer_replace(request, layername, template='layers/layer_replace.html'):
                                   RequestContext(request, ctx))
     elif request.method == 'POST':
 
-        form = LayerUploadForm(request.POST, request.FILES)
+        form = NewLayerUploadForm(request.POST, request.FILES)
         tempdir = None
         out = {}
 

--- a/geonode/local_settings.py.qgis.sample
+++ b/geonode/local_settings.py.qgis.sample
@@ -98,8 +98,8 @@ QGIS_SERVER_URL = os.environ.get(
     'QGIS_SERVER_URL', 'http://qgis-server/')
 QGIS_SERVER_CONFIG = {
     'tiles_directory': tiles_directory,
-    'tile_path': tiles_directory + '/%s/%d/%d/%d.png',
-    'legend_path': tiles_directory + '/%s/legend.png',
+    'tile_path': tiles_directory + '/%s/%s/%d/%d/%d.png',
+    'legend_path': tiles_directory + '/%s/%s/legend.png',
     'thumbnail_path': tiles_directory + '/%s/thumbnail.png',
     'map_tile_path': os.path.join(
         tiles_directory, '%s', 'map_tiles', '%s', '%s', '%s', '%s.png'),

--- a/geonode/qgis_server/admin.py
+++ b/geonode/qgis_server/admin.py
@@ -19,7 +19,7 @@
 #########################################################################
 
 from django.contrib import admin
-from geonode.qgis_server.models import QGISServerLayer
+from geonode.qgis_server.models import QGISServerLayer, QGISServerStyle
 
 
 # Register your models here.
@@ -30,4 +30,13 @@ class QGISServerLayerAdmin(admin.ModelAdmin):
     ]
 
 
+class QGISServerStyleAdmin(admin.ModelAdmin):
+    list_display = [
+        'name',
+        'title',
+        'style_url'
+    ]
+
+
 admin.site.register(QGISServerLayer, QGISServerLayerAdmin)
+admin.site.register(QGISServerStyle, QGISServerStyleAdmin)

--- a/geonode/qgis_server/forms.py
+++ b/geonode/qgis_server/forms.py
@@ -21,6 +21,7 @@ import os
 
 from django import forms
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 
 
 def _extension_validator(value):
@@ -31,4 +32,18 @@ def _extension_validator(value):
 
 class QGISLayerStyleUploadForm(forms.Form):
 
-    qml = forms.FileField(label='QML', validators=[_extension_validator])
+    alphanumeric = RegexValidator(
+        r'^[0-9a-zA-Z_]*$',
+        'Only alphanumeric and underscore characters are allowed.')
+
+    name = forms.CharField(
+        label='Name', required=True,
+        help_text='Name identifier for style',
+        validators=[alphanumeric])
+    title = forms.CharField(
+        label='Title', required=True,
+        help_text='Human friendly title for style')
+    qml = forms.FileField(
+        label='QML',
+        help_text='QGIS Style file (QML)',
+        validators=[_extension_validator])

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -18,26 +18,30 @@
 #
 #########################################################################
 import logging
+import math
 import os
 import re
 import shutil
 import urllib
 from urlparse import urljoin
 
-import math
 import requests
 from django.conf import settings
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
+from lxml import etree
 from requests import Request
 
 from geonode import qgis_server
 from geonode.geoserver.helpers import OGC_Servers_Handler
 from geonode.layers.models import Layer
 from geonode.qgis_server.gis_tools import num2deg
-from geonode.qgis_server.models import QGISServerLayer, QGISServerMap
+from geonode.qgis_server.models import (
+    QGISServerLayer,
+    QGISServerMap,
+    QGISServerStyle)
 
 logger = logging.getLogger(__file__)
 ogc_server_settings = OGC_Servers_Handler(settings.OGC_SERVER)['default']
@@ -425,6 +429,241 @@ def legend_url(layer, layertitle=False, internal=True):
     return url
 
 
+def wms_get_capabilities_url(layer=None, internal=True):
+    """Construct WMS GetCapabilities request.
+
+    :param layer: Layer to inspect
+    :type layer: Layer
+
+    :param internal: Flag to switch between public url and internal url.
+        Public url will be served by Django Geonode (proxified).
+    :type internal: bool
+
+    :return: QGIS Server request url
+    :rtype: str
+    """
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer {0}'.format(layer.name)
+        logger.debug(msg)
+        raise
+
+    qgis_project_path = qgis_layer.qgis_project_path
+
+    query_string = {
+        'MAP': qgis_project_path,
+        'SERVICE': 'WMS',
+        'VERSION': '1.3.0',
+        'REQUEST': 'GetCapabilities',
+        'LAYER': layer.name
+    }
+
+    qgis_server_url = qgis_server_endpoint(internal)
+    url = Request('GET', qgis_server_url, params=query_string).prepare().url
+    return url
+
+
+def style_get_url(layer, style_name, internal=True):
+    """Get QGIS Server style as xml.
+
+    :param layer: Layer to inspect
+    :type layer: Layer
+
+    :param style_name: Style name as given by QGIS Server
+    :type style_name: str
+
+    :param internal: Flag to switch between public url and internal url.
+        Public url will be served by Django Geonode (proxified).
+    :type internal: bool
+
+    :return: QGIS Server request url
+    :rtype: str
+    """
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer {0}'.format(layer.name)
+        logger.debug(msg)
+        raise
+
+    qgis_project_path = qgis_layer.qgis_project_path
+
+    query_string = {
+        'PROJECT': qgis_project_path,
+        'SERVICE': 'STYLEMANAGER',
+        'REQUEST': 'GetStyle',
+        'LAYER': layer.name,
+        'NAME': style_name
+    }
+
+    qgis_server_url = qgis_server_endpoint(internal)
+    url = Request('GET', qgis_server_url, params=query_string).prepare().url
+    return url
+
+
+def style_add_url(layer, style_name, internal=True):
+    """Add QGIS Server style to QGIS Project.
+
+    This style file is stored on qml LayerFile in upload_session.
+    After the file is uploaded, it has to be deleted.
+
+    :param layer: Layer to inspect
+    :type layer: Layer
+
+    :param style_name: Style name as given by QGIS Server
+    :type style_name: str
+
+    :param internal: Flag to switch between public url and internal url.
+        Public url will be served by Django Geonode (proxified).
+    :type internal: bool
+
+    :return: QGIS Server request url
+    :rtype: str
+    """
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer {0}'.format(layer.name)
+        logger.debug(msg)
+        raise
+
+    qgis_project_path = qgis_layer.qgis_project_path
+
+    # QML File is taken from uploaded file
+    query_string = {
+        'SERVICE': 'STYLEMANAGER',
+        'PROJECT': qgis_project_path,
+        'REQUEST': 'AddStyle',
+        'LAYER': layer.name,
+        'NAME': style_name,
+        'QML': qgis_layer.qml_path,
+        'REMOVEQML': 'TRUE'
+    }
+
+    qgis_server_url = qgis_server_endpoint(internal)
+    url = Request('GET', qgis_server_url, params=query_string).prepare().url
+    return url
+
+
+def style_remove_url(layer, style_name, internal=True):
+    """Remove QGIS Server style from QGIS Project.
+
+    :param layer: Layer to inspect
+    :type layer: Layer
+
+    :param style_name: Style name as given by QGIS Server
+    :type style_name: str
+
+    :param internal: Flag to switch between public url and internal url.
+        Public url will be served by Django Geonode (proxified).
+    :type internal: bool
+
+    :return: QGIS Server request url
+    :rtype: str
+    """
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer {0}'.format(layer.name)
+        logger.debug(msg)
+        raise
+
+    qgis_project_path = qgis_layer.qgis_project_path
+
+    query_string = {
+        'SERVICE': 'STYLEMANAGER',
+        'PROJECT': qgis_project_path,
+        'REQUEST': 'RemoveStyle',
+        'LAYER': layer.name,
+        'NAME': style_name
+    }
+
+    qgis_server_url = qgis_server_endpoint(internal)
+    url = Request('GET', qgis_server_url, params=query_string).prepare().url
+    return url
+
+
+def style_set_default_url(layer, style_name, internal=True):
+    """Remove QGIS Server style from QGIS Project.
+
+    :param layer: Layer to inspect
+    :type layer: Layer
+
+    :param style_name: Style name as given by QGIS Server
+    :type style_name: str
+
+    :param internal: Flag to switch between public url and internal url.
+        Public url will be served by Django Geonode (proxified).
+    :type internal: bool
+
+    :return: QGIS Server request url
+    :rtype: str
+    """
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer {0}'.format(layer.name)
+        logger.debug(msg)
+        raise
+
+    qgis_project_path = qgis_layer.qgis_project_path
+
+    query_string = {
+        'SERVICE': 'STYLEMANAGER',
+        'PROJECT': qgis_project_path,
+        'REQUEST': 'SetDefaultStyle',
+        'LAYER': layer.name,
+        'NAME': style_name
+    }
+
+    qgis_server_url = qgis_server_endpoint(internal)
+    url = Request('GET', qgis_server_url, params=query_string).prepare().url
+    return url
+
+
+def style_list(layer, internal=True):
+    """Query list of styles from QGIS Server.
+
+    :param layer: Layer to inspect
+    :type layer: Layer
+
+    :param internal: Flag to switch between public url and internal url.
+        Public url will be served by Django Geonode (proxified).
+    :type internal: bool
+
+    :return: List of QGISServerStyle
+    :rtype: list(QGISServerStyle)
+    """
+    # We get the list of style from GetCapabilities request
+    # Must call from public URL because we need public LegendURL
+    url = wms_get_capabilities_url(layer, internal=internal)
+    response = requests.get(url)
+
+    root_xml = etree.fromstring(response.content)
+    styles_xml = root_xml.xpath(
+        'wms:Capability/wms:Layer/wms:Layer/wms:Style',
+        namespaces={
+            'xlink': 'http://www.w3.org/1999/xlink',
+            'wms': 'http://www.opengis.net/wms'
+        })
+
+    # Fetch styles body
+    try:
+        qgis_layer = QGISServerLayer.objects.get(layer=layer)
+    except QGISServerLayer.DoesNotExist:
+        msg = 'No QGIS Server Layer for existing layer {0}'.format(layer.name)
+        logger.debug(msg)
+        raise
+
+    styles_obj = [
+        QGISServerStyle.from_get_capabilities_style_xml(
+            qgis_layer, style_xml)[0]
+        for style_xml in styles_xml]
+
+    return styles_obj
+
+
 def create_qgis_project(
         layer, qgis_project_path, overwrite=False, internal=True):
     """Create a new QGS Project for a given layer.
@@ -468,6 +707,7 @@ def create_qgis_project(
         'FILES': files,
         'NAMES': names,
         'OVERWRITE': overwrite,
+        'REMOVEQML': 'TRUE'
     }
     qgis_server_url = qgis_server_endpoint(internal)
     response = requests.get(qgis_server_url, params=query_string)

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -148,7 +148,11 @@ def qgis_server_endpoint(internal=True):
         # The generated URL is not a direct URL to QGIS Server,
         # but it was a proxy from django instead.
         endpoint_url = reverse('qgis_server:request')
-        site_url = settings.SITEURL
+
+        if hasattr(settings, 'TESTING') and settings.TESTING:
+            site_url = 'http://localhost:8000'
+        else:
+            site_url = settings.SITEURL
         qgis_server_url = urljoin(site_url, endpoint_url)
         return qgis_server_url
 

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -157,7 +157,7 @@ def qgis_server_endpoint(internal=True):
         return qgis_server_url
 
 
-def tile_url_format(layer_name):
+def tile_url_format(layer_name, style=None):
     """Construct proxied QGIS Server URL format for tiles.
 
     This url is not an actual request, but rather a format url
@@ -170,11 +170,14 @@ def tile_url_format(layer_name):
     :return: Tile url
     :rtype: basestring
     """
+    url_kwargs = {
+        'layername': layer_name
+    }
+    if style:
+        url_kwargs['style'] = style
     url = reverse(
         'qgis_server:tile',
-        kwargs={
-            'layername': layer_name
-        })
+        kwargs=url_kwargs)
     # unquote url
     # so that {z}/{x}/{y} is not quoted
     url = urllib.unquote(url)
@@ -182,7 +185,7 @@ def tile_url_format(layer_name):
     return url
 
 
-def tile_url(layer, z, x, y, internal=True):
+def tile_url(layer, z, x, y, style=None, internal=True):
     """Construct actual tile request to QGIS Server.
 
     Different than tile_url_format, this method will return url for requesting
@@ -199,6 +202,9 @@ def tile_url(layer, z, x, y, internal=True):
 
     :param y: TMS coordinate, latitude parameter
     :type y: int, str
+
+    :param style: Layer style to choose
+    :type style: str
 
     :param internal: Flag to switch between public url and internal url.
         Public url will be served by Django Geonode (proxified).
@@ -236,6 +242,12 @@ def tile_url(layer, z, x, y, internal=True):
 
     bbox = ','.join([str(val) for val in [left, bottom, right, top]])
 
+    if not style:
+        style = 'default'
+
+    if style not in [s.name for s in qgis_layer.styles.all()]:
+        style = qgis_layer.default_style.name
+
     query_string = {
         'SERVICE': 'WMS',
         'VERSION': '1.3.0',
@@ -246,7 +258,7 @@ def tile_url(layer, z, x, y, internal=True):
         'HEIGHT': '256',
         'MAP': qgis_layer.qgis_project_path,
         'LAYERS': layer.name,
-        'STYLES': 'default',
+        'STYLE': style,
         'FORMAT': 'image/png',
         'TRANSPARENT': 'true',
         'DPI': '96',
@@ -297,11 +309,14 @@ def map_thumbnail_url(instance, bbox=None, internal=True):
         bbox, qgis_map.qgis_map_name, qgis_project, internal=internal)
 
 
-def layer_thumbnail_url(instance, bbox=None, internal=True):
+def layer_thumbnail_url(instance, style=None, bbox=None, internal=True):
     """Construct QGIS Server Url to fetch remote layer thumbnail.
 
     :param instance: Layer object
     :type instance: geonode.layers.models.Layer
+
+    :param style: Layer style to choose
+    :type style: str
 
     :param bbox: Bounding box of thumbnail in 4 tuple format
         [xmin,ymin,xmax,ymax]
@@ -325,15 +340,21 @@ def layer_thumbnail_url(instance, bbox=None, internal=True):
     qgis_project = qgis_layer.qgis_project_path
     layers = instance.name
 
+    if not style:
+        style = 'default'
+
+    if style not in [s.name for s in qgis_layer.styles.all()]:
+        style = qgis_layer.default_style.name
+
     if not bbox:
         # We get the extent of the layer.
         # Reproject, in case of different CRS
         bbox = transform_layer_bbox(instance, 4326)
 
-    return thumbnail_url(bbox, layers, qgis_project, internal=internal)
+    return thumbnail_url(bbox, layers, qgis_project, style=style, internal=internal)
 
 
-def thumbnail_url(bbox, layers, qgis_project, internal=True):
+def thumbnail_url(bbox, layers, qgis_project, style=None, internal=True):
     """Internal function to generate the URL for the thumbnail.
 
     :param bbox: The bounding box to use in the format [left,bottom,right,top].
@@ -345,6 +366,9 @@ def thumbnail_url(bbox, layers, qgis_project, internal=True):
     :param qgis_project: The path to the QGIS project.
     :type qgis_project: basestring
 
+    :param style: Layer style to choose
+    :type style: str
+
     :param internal: Flag to switch between public url and internal url.
         Public url will be served by Django Geonode (proxified).
     :type internal: bool
@@ -352,6 +376,7 @@ def thumbnail_url(bbox, layers, qgis_project, internal=True):
     :return: The WMS URL to fetch the thumbnail.
     :rtype: basestring
     """
+
     x_min, y_min, x_max, y_max = bbox
     # We calculate the margins according to 10 percent.
     percent = 10
@@ -378,7 +403,7 @@ def thumbnail_url(bbox, layers, qgis_project, internal=True):
         'HEIGHT': '250',
         'MAP': qgis_project,
         'LAYERS': layers,
-        'STYLES': 'default',
+        'STYLE': style,
         'FORMAT': 'image/png',
         'TRANSPARENT': 'true',
         'DPI': '96',
@@ -390,7 +415,7 @@ def thumbnail_url(bbox, layers, qgis_project, internal=True):
     return url
 
 
-def legend_url(layer, layertitle=False, internal=True):
+def legend_url(layer, layertitle=False, style=None, internal=True):
     """Construct QGIS Server url to fetch legend.
 
     :param layer: Layer to use
@@ -398,6 +423,9 @@ def legend_url(layer, layertitle=False, internal=True):
 
     :param layertitle: Layer title flag. Set to True to include layer title
     :type layertitle: bool
+
+    :param style: Layer style to choose
+    :type style: str
 
     :param internal: Flag to switch between public url and internal url.
         Public url will be served by Django Geonode (proxified).
@@ -415,6 +443,12 @@ def legend_url(layer, layertitle=False, internal=True):
 
     qgis_project_path = qgis_layer.qgis_project_path
 
+    if not style:
+        style = 'default'
+
+    if style not in [s.name for s in qgis_layer.styles.all()]:
+        style = qgis_layer.default_style.name
+
     query_string = {
         'MAP': qgis_project_path,
         'SERVICE': 'WMS',
@@ -423,6 +457,7 @@ def legend_url(layer, layertitle=False, internal=True):
         'LAYER': layer.name,
         'LAYERTITLE': str(layertitle).lower(),
         'FORMAT': 'image/png',
+        'STYLE': style,
         'TILED': 'true',
         'TRANSPARENT': 'true',
         'LEGEND_OPTIONS': (
@@ -665,6 +700,27 @@ def style_list(layer, internal=True):
             qgis_layer, style_xml)[0]
         for style_xml in styles_xml]
 
+    # Manage orphaned styles
+    style_names = [s.name for s in styles_obj]
+    for style in qgis_layer.styles.all():
+        if style.name not in style_names:
+            if style == qgis_layer.default_style:
+                qgis_layer.default_style = None
+                qgis_layer.save()
+            style.delete()
+
+    # Set default style if not yet set
+    set_default_style = False
+    try:
+        if not qgis_layer.default_style:
+            set_default_style = True
+    except:
+        set_default_style = True
+
+    if set_default_style and styles_obj:
+        qgis_layer.default_style = styles_obj[0]
+        qgis_layer.save()
+
     return styles_obj
 
 
@@ -711,7 +767,7 @@ def create_qgis_project(
         'FILES': files,
         'NAMES': names,
         'OVERWRITE': overwrite,
-        'REMOVEQML': 'TRUE'
+        'REMOVEQML': True
     }
     qgis_server_url = qgis_server_endpoint(internal)
     response = requests.get(qgis_server_url, params=query_string)

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -43,7 +43,7 @@ from geonode.qgis_server.models import (
     QGISServerMap,
     QGISServerStyle)
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger("geonode.qgis_server.helpers")
 ogc_server_settings = OGC_Servers_Handler(settings.OGC_SERVER)['default']
 
 
@@ -661,7 +661,7 @@ def style_set_default_url(layer, style_name, internal=True):
     return url
 
 
-def style_list(layer, internal=True):
+def style_list(layer, internal=True, generating_qgis_capabilities=False):
     """Query list of styles from QGIS Server.
 
     :param layer: Layer to inspect
@@ -670,6 +670,12 @@ def style_list(layer, internal=True):
     :param internal: Flag to switch between public url and internal url.
         Public url will be served by Django Geonode (proxified).
     :type internal: bool
+
+    :param generating_qgis_capabilities: internal Flag for the method to tell
+        that this function were executed to generate QGIS GetCapabilities
+        request for querying Style list. This flag is used for recursion.
+        Default to False as recursion base.
+    :type generating_qgis_capabilities: bool
 
     :return: List of QGISServerStyle
     :rtype: list(QGISServerStyle)
@@ -699,6 +705,36 @@ def style_list(layer, internal=True):
         QGISServerStyle.from_get_capabilities_style_xml(
             qgis_layer, style_xml)[0]
         for style_xml in styles_xml]
+
+    # Only tried to generate/fix QGIS GetCapabilities to return correct style
+    # list, if:
+    # - the current request return empty styles_obj (no styles, not possible)
+    # - does not currently tried to generate QGIS GetCapabilities to fix this
+    #   problem
+    if not styles_obj and not generating_qgis_capabilities:
+        # It's not possible to have empty style. There will always be default
+        # style.
+        # Initiate a dummy requests to trigger build style list on QGIS Server
+        # side
+
+        # write an empty file if it doesn't exists
+        open(qgis_layer.qml_path, 'a').close()
+
+        # Basically add a new style then deletes it to force QGIS to refresh
+        # style list in project properties. We don't care the request result.
+        dummy_style_name = '__tmp__dummy__name__'
+        style_url = style_add_url(layer, dummy_style_name)
+        requests.get(style_url)
+        style_url = style_remove_url(layer, dummy_style_name)
+        requests.get(style_url)
+
+        # End the requests and rely on the next request to build style models
+        # to avoid infinite recursion
+
+        # Set generating_qgis_capabilities flag to True to avoid next
+        # recursion
+        return style_list(
+            layer, internal=internal, generating_qgis_capabilities=True)
 
     # Manage orphaned styles
     style_names = [s.name for s in styles_obj]

--- a/geonode/qgis_server/migrations/0003_auto_20170727_0509.py
+++ b/geonode/qgis_server/migrations/0003_auto_20170727_0509.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('qgis_server', '0002_qgisservermap'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='QGISServerStyle',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=255, verbose_name='style name')),
+                ('title', models.CharField(max_length=255, null=True, blank=True)),
+                ('body', models.TextField(null=True, verbose_name='style xml', blank=True)),
+                ('style_url', models.CharField(max_length=1000, null=True, verbose_name='style url')),
+                ('style_legend_url', models.CharField(max_length=1000, null=True, verbose_name='style legend url')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='qgisserverlayer',
+            name='default_style',
+            field=models.ForeignKey(related_name='layer_default_style', default=None, to='qgis_server.QGISServerStyle', null=True),
+        ),
+        migrations.AddField(
+            model_name='qgisserverlayer',
+            name='styles',
+            field=models.ManyToManyField(related_name='layer_styles', to='qgis_server.QGISServerStyle'),
+        ),
+    ]

--- a/geonode/qgis_server/migrations/0004_auto_20170805_0223.py
+++ b/geonode/qgis_server/migrations/0004_auto_20170805_0223.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('qgis_server', '0003_auto_20170727_0509'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='qgisserverlayer',
+            name='layer',
+            field=models.OneToOneField(related_name='qgis_layer', primary_key=True, serialize=False, to='layers.Layer'),
+        ),
+        migrations.AlterField(
+            model_name='qgisserverstyle',
+            name='name',
+            field=models.CharField(max_length=255, verbose_name='style name'),
+        ),
+    ]

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -219,7 +219,7 @@ class QGISServerStyle(models.Model):
 
         filter_dict = {
             'name': style_xml.xpath(
-                'wms:Style/wms:Name', namespaces=namespaces)[0].text,
+                'wms:Name', namespaces=namespaces)[0].text,
 
             'layer_default_style': qgis_layer
         }
@@ -235,10 +235,10 @@ class QGISServerStyle(models.Model):
 
         default_dict = {
             'title': style_xml.xpath(
-                'wms:Style/wms:Title', namespaces=namespaces)[0].text,
+                'wms:Title', namespaces=namespaces)[0].text,
 
             'style_legend_url': style_xml.xpath(
-                'wms:Style/wms:LegendURL/wms:OnlineResource',
+                'wms:LegendURL/wms:OnlineResource',
                 namespaces=namespaces)[0].attrib[
                 '{http://www.w3.org/1999/xlink}href'],
 
@@ -247,10 +247,19 @@ class QGISServerStyle(models.Model):
             'body': style_body
         }
 
-        filter_dict['defaults'] = default_dict
+        # filter_dict['defaults'] = default_dict
 
-        style_obj, created = QGISServerLayer.objects.get_or_create(
-            **filter_dict)
+        # Can't use get_or_create function for some reason.
+        # So use regular query
+
+        try:
+            style_obj = QGISServerStyle.objects.get(**filter_dict)
+            created = False
+        except QGISServerStyle.DoesNotExist:
+            style_obj = QGISServerStyle(**default_dict)
+            style_obj.name = filter_dict['name']
+            style_obj.save()
+            created = True
 
         if not created and synchronize:
             # Try to synchronize this model with the given parameters

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -58,7 +58,7 @@ class QGISServerLayer(models.Model):
     layer = models.OneToOneField(
         Layer,
         primary_key=True,
-        name='layer'
+        related_name='qgis_layer'
     )
     base_layer_path = models.CharField(
         name='base_layer_path',
@@ -171,11 +171,15 @@ class QGISServerLayer(models.Model):
         except OSError:
             pass
 
+        # Removing orphaned styles
+        for style in QGISServerStyle.objects.filter(layer_styles=None):
+            style.delete()
+
 
 class QGISServerStyle(models.Model):
     """Model wrapper for QGIS Server styles."""
 
-    name = models.CharField(_('style name'), max_length=255, unique=True)
+    name = models.CharField(_('style name'), max_length=255)
     title = models.CharField(max_length=255, null=True, blank=True)
     body = models.TextField(_('style xml'), null=True, blank=True)
     style_url = models.CharField(_('style url'), null=True, max_length=1000)
@@ -221,13 +225,14 @@ class QGISServerStyle(models.Model):
             'name': style_xml.xpath(
                 'wms:Name', namespaces=namespaces)[0].text,
 
-            'layer_default_style': qgis_layer
+            'layer_styles': qgis_layer
         }
 
         # if style_body is none, try fetch it from QGIS Server
         if not style_url:
             from geonode.qgis_server.helpers import style_get_url
-            style_url = style_get_url(qgis_layer.layer, filter_dict['name'])
+            style_url = style_get_url(
+                qgis_layer.layer, filter_dict['name'], internal=False)
 
         response = requests.get(style_url)
         style_body = etree.tostring(
@@ -261,10 +266,9 @@ class QGISServerStyle(models.Model):
             style_obj.save()
             created = True
 
-        if not created and synchronize:
+        if created or synchronize:
             # Try to synchronize this model with the given parameters
             style_obj.name = filter_dict['name']
-            style_obj.layer_default_style = filter_dict['layer_default_style']
 
             style_obj.style_url = default_dict['style_url']
             style_obj.body = default_dict['body']
@@ -272,7 +276,25 @@ class QGISServerStyle(models.Model):
             style_obj.style_legend_url = default_dict['style_legend_url']
             style_obj.save()
 
+            style_obj.layer_styles.add(qgis_layer)
+            style_obj.save()
+
         return style_obj, created
+
+    @property
+    def style_tile_cache_path(self):
+        """Returned the location of tile cache for this layer style.
+
+        Example base path: /usr/src/app/geonode/qgis_layer/jakarta_flood.shp
+
+        QGIS cache path: /usr/src/app/geonode/qgis_tiles/jakarta_flood/
+            default_style
+
+        :return: Base path of layer cache
+        :rtype: str
+        """
+        return os.path.join(
+            QGIS_TILES_DIRECTORY, self.layer_styles.first().layer.name, self.name)
 
 
 class QGISServerMap(models.Model):

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -21,9 +21,13 @@
 import logging
 import os
 from shutil import rmtree
+from xml.etree import ElementTree
 
+import requests
 from django.conf import settings
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
+from lxml import etree
 
 from geonode import qgis_server
 from geonode.layers.models import Layer
@@ -62,6 +66,15 @@ class QGISServerLayer(models.Model):
         help_text='Location of the base layer.',
         max_length=100
     )
+
+    default_style = models.ForeignKey(
+        'QGISServerStyle',
+        related_name='layer_default_style',
+        default=None,
+        null=True)
+    styles = models.ManyToManyField(
+        'QGISServerStyle',
+        related_name='layer_styles')
 
     @property
     def files(self):
@@ -157,6 +170,100 @@ class QGISServerLayer(models.Model):
             rmtree(path)
         except OSError:
             pass
+
+
+class QGISServerStyle(models.Model):
+    """Model wrapper for QGIS Server styles."""
+
+    name = models.CharField(_('style name'), max_length=255, unique=True)
+    title = models.CharField(max_length=255, null=True, blank=True)
+    body = models.TextField(_('style xml'), null=True, blank=True)
+    style_url = models.CharField(_('style url'), null=True, max_length=1000)
+    style_legend_url = models.CharField(
+        _('style legend url'), null=True, max_length=1000)
+
+    @classmethod
+    def from_get_capabilities_style_xml(
+            cls, qgis_layer, style_xml, style_url=None, synchronize=True):
+        """Convert to this model from GetCapabilities Style tag.
+
+        :param qgis_layer: Associated QGIS Server Layer
+        :type qgis_layer: QGISServerLayer
+
+        :param style_xml: xml string or object
+        :type style_xml: str | lxml.etree.Element |
+            xml.etree.ElementTree.Element
+
+        :param style_url: style information stored as xml
+        :type style_url: str
+
+        :param synchronize: Flag, if true then synchronize the new value
+        :type synchronize: bool
+
+        :return: QGISServerStyle model and boolean flag created
+        :rtype: QGISServerStyle, bool
+        """
+
+        if isinstance(style_xml, str):
+            style_xml = etree.fromstring(style_xml)
+
+        elif isinstance(style_xml, ElementTree.Element):
+            style_xml = etree.fromstring(
+                ElementTree.tostring(
+                    style_xml, encoding='utf-8', method='xml'))
+
+        namespaces = {
+            'wms': 'http://www.opengis.net/wms',
+            'xlink': 'http://www.w3.org/1999/xlink'
+        }
+
+        filter_dict = {
+            'name': style_xml.xpath(
+                'wms:Style/wms:Name', namespaces=namespaces)[0].text,
+
+            'layer_default_style': qgis_layer
+        }
+
+        # if style_body is none, try fetch it from QGIS Server
+        if not style_url:
+            from geonode.qgis_server.helpers import style_get_url
+            style_url = style_get_url(qgis_layer.layer, filter_dict['name'])
+
+        response = requests.get(style_url)
+        style_body = etree.tostring(
+            etree.fromstring(response.content), pretty_print=True)
+
+        default_dict = {
+            'title': style_xml.xpath(
+                'wms:Style/wms:Title', namespaces=namespaces)[0].text,
+
+            'style_legend_url': style_xml.xpath(
+                'wms:Style/wms:LegendURL/wms:OnlineResource',
+                namespaces=namespaces)[0].attrib[
+                '{http://www.w3.org/1999/xlink}href'],
+
+            'style_url': style_url,
+
+            'body': style_body
+        }
+
+        filter_dict['defaults'] = default_dict
+
+        style_obj, created = QGISServerLayer.objects.get_or_create(
+            **filter_dict)
+
+        if not created and synchronize:
+            # Try to synchronize this model with the given parameters
+            style_obj.name = filter_dict['name']
+            style_obj.layer_default_style = filter_dict['layer_default_style']
+
+            style_obj.style_url = default_dict['style_url']
+            style_obj.body = default_dict['body']
+            style_obj.title = default_dict['title']
+            style_obj.style_legend_url = default_dict['style_legend_url']
+            style_obj.save()
+
+        return style_obj, created
 
 
 class QGISServerMap(models.Model):

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -245,6 +245,9 @@ def qgis_server_post_save(instance, sender, **kwargs):
         instance, qgis_layer.qgis_project_path, overwrite=overwrite,
         internal=True)
 
+    # Generate style model cache
+    style_list(instance, internal=False)
+
     # Remove QML file if necessary
     try:
         qml_file = instance.upload_session.layerfile_set.get(name='qml')
@@ -341,9 +344,6 @@ def qgis_server_post_save(instance, sender, **kwargs):
             update_xml(xml_file_path, new_values)
         except (TypeError, AttributeError):
             pass
-
-    # Generate style cache
-    style_list(instance, internal=False)
 
     # Remove existing tile caches if overwrite
     if overwrite:

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -32,7 +32,7 @@ from requests.compat import urljoin
 
 from geonode import qgis_server
 from geonode.base.models import Link
-from geonode.layers.models import Layer
+from geonode.layers.models import Layer, LayerFile
 from geonode.maps.models import Map, MapLayer
 from geonode.qgis_server.gis_tools import set_attributes
 from geonode.qgis_server.helpers import tile_url_format, create_qgis_project
@@ -86,6 +86,12 @@ def qgis_server_post_save(instance, sender, **kwargs):
 
     This hook also creates QGIS Project. Which is essentials for QGIS Server.
     There are also several Geonode Links generated, like thumbnail and legends
+
+    :param instance: geonode Layer
+    :type instance: Layer
+
+    :param sender: geonode Layer type
+    :type sender: type(Layer)
     """
     if not sender == Layer:
         return
@@ -240,6 +246,14 @@ def qgis_server_post_save(instance, sender, **kwargs):
     response = create_qgis_project(
         instance, qgis_layer.qgis_project_path, overwrite=overwrite,
         internal=True)
+
+    # Remove QML file if necessary
+    try:
+        qml_file = instance.upload_session.layerfile_set.get(name='qml')
+        if not os.path.exists(qml_file.file.path):
+            qml_file.delete()
+    except LayerFile.DoesNotExist:
+        pass
 
     logger.debug('Creating the QGIS Project : %s' % response.url)
     if response.content != 'OK':

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -35,7 +35,8 @@ from geonode.base.models import Link
 from geonode.layers.models import Layer, LayerFile
 from geonode.maps.models import Map, MapLayer
 from geonode.qgis_server.gis_tools import set_attributes
-from geonode.qgis_server.helpers import tile_url_format, create_qgis_project
+from geonode.qgis_server.helpers import tile_url_format, create_qgis_project, \
+    style_list
 from geonode.qgis_server.models import QGISServerLayer, QGISServerMap
 from geonode.qgis_server.tasks.update import create_qgis_server_thumbnail
 from geonode.qgis_server.xml_utilities import update_xml
@@ -184,12 +185,11 @@ def qgis_server_post_save(instance, sender, **kwargs):
         link_mime = 'ZIP'
 
     # Zip file
-    Link.objects.get_or_create(
+    Link.objects.update_or_create(
         resource=instance.resourcebase_ptr,
-        url=zip_download_url,
+        name=link_name,
         defaults=dict(
             extension='zip',
-            name=link_name,
             mime=link_mime,
             url=zip_download_url,
             link_type='data'
@@ -203,13 +203,12 @@ def qgis_server_post_save(instance, sender, **kwargs):
             'qgis_server:layer-request', kwargs={'layername': instance.name}))
     ogc_wms_name = 'OGC WMS: %s Service' % instance.workspace
     ogc_wms_link_type = 'OGC:WMS'
-    Link.objects.get_or_create(
+    Link.objects.update_or_create(
         resource=instance.resourcebase_ptr,
-        url=ogc_wms_url,
+        name=ogc_wms_name,
         link_type=ogc_wms_link_type,
         defaults=dict(
             extension='html',
-            name=ogc_wms_name,
             url=ogc_wms_url,
             mime='text/html',
             link_type=ogc_wms_link_type
@@ -225,13 +224,12 @@ def qgis_server_post_save(instance, sender, **kwargs):
                 kwargs={'layername': instance.name}))
         ogc_wfs_name = 'OGC WFS: %s Service' % instance.workspace
         ogc_wfs_link_type = 'OGC:WFS'
-        Link.objects.get_or_create(
+        Link.objects.update_or_create(
             resource=instance.resourcebase_ptr,
-            url=ogc_wfs_url,
+            name=ogc_wfs_name,
             link_type=ogc_wfs_link_type,
             defaults=dict(
                 extension='html',
-                name=ogc_wfs_name,
                 url=ogc_wfs_url,
                 mime='text/html',
                 link_type=ogc_wfs_link_type
@@ -259,12 +257,12 @@ def qgis_server_post_save(instance, sender, **kwargs):
     if response.content != 'OK':
         logger.debug('Result : %s' % response.content)
 
-    Link.objects.get_or_create(
+    Link.objects.update_or_create(
         resource=instance.resourcebase_ptr,
-        url=tile_url_format(instance.name),
+        name="Tiles",
         defaults=dict(
+            url=tile_url_format(instance.name),
             extension='tiles',
-            name="Tiles",
             mime='image/png',
             link_type='image'
         )
@@ -277,12 +275,12 @@ def qgis_server_post_save(instance, sender, **kwargs):
         geotiff_url = urljoin(base_url, geotiff_url)
         logger.debug('geotif_url: %s' % geotiff_url)
 
-        Link.objects.get_or_create(
+        Link.objects.update_or_create(
             resource=instance.resourcebase_ptr,
-            url=geotiff_url,
+            name="GeoTIFF",
             defaults=dict(
                 extension=original_ext.split('.')[-1],
-                name="GeoTIFF",
+                url=geotiff_url,
                 mime='image/tiff',
                 link_type='image'
             )
@@ -294,12 +292,11 @@ def qgis_server_post_save(instance, sender, **kwargs):
         kwargs={'layername': instance.name}
     )
     legend_url = urljoin(base_url, legend_url)
-    Link.objects.get_or_create(
+    Link.objects.update_or_create(
         resource=instance.resourcebase_ptr,
-        url=legend_url,
+        name='Legend',
         defaults=dict(
             extension='png',
-            name='Legend',
             url=legend_url,
             mime='image/png',
             link_type='image',
@@ -344,6 +341,9 @@ def qgis_server_post_save(instance, sender, **kwargs):
             update_xml(xml_file_path, new_values)
         except (TypeError, AttributeError):
             pass
+
+    # Generate style cache
+    style_list(instance, internal=False)
 
     # Remove existing tile caches if overwrite
     if overwrite:

--- a/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
+++ b/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
@@ -13,7 +13,7 @@
 {% trans "You may also use browser reload." %}
 </p>
 {% else %}
-<form id="qgis-server-style-edit-form" method="post" action="{% url "qgis_server:update-qml" layername=resource.name %}" enctype="multipart/form-data">
+<form id="qgis-server-style-edit-form" method="post" action="{% url "qgis_server:upload-qml" layername=resource.name %}" enctype="multipart/form-data">
     {% csrf_token %}
     {{ style_upload_form|as_bootstrap }}
     {% if use_qml_style %}

--- a/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
+++ b/geonode/qgis_server/templates/qgis_server/forms/qml_style.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load bootstrap_tags %}
 
-{% if success %}
+{% if page_reload %}
 <script type="text/javascript">
     window.location.reload()
 </script>
@@ -13,12 +13,76 @@
 {% trans "You may also use browser reload." %}
 </p>
 {% else %}
-<form id="qgis-server-style-edit-form" method="post" action="{% url "qgis_server:upload-qml" layername=resource.name %}" enctype="multipart/form-data">
-    {% csrf_token %}
-    {{ style_upload_form|as_bootstrap }}
-    {% if use_qml_style %}
-        <a href="{% url "qgis_server:download-qml" layername=resource.name %}" class="btn btn-default">{% trans "Download Current Style" %}</a>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>{% trans "Name" %}</th>
+                <th>{% trans "Title" %}</th>
+                <th>{% trans "Action" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for style in resource.qgis_layer.styles.all %}
+                <tr>
+                    <td>
+                        {{ style.name|safe }}
+                        {% if resource.qgis_layer.default_style.name == style.name %}
+                            (default style)
+                        {% endif %}
+                    </td>
+                    <td>{{ style.title|safe }}</td>
+                    <td>
+                        {% if resource.qgis_layer.default_style.name != style.name %}
+                            <button class="btn btn-primary" onclick="qml_set_default_style('{% url "qgis_server:default-qml" layername=resource.name style_name=style.name %}')">{% trans "Set As Default Style" %}</button>
+                        {% endif %}
+                        <a href="{% url "qgis_server:download-qml" layername=resource.name style_name=style.name %}" class="btn btn-primary">{% trans "Download Style" %}</a>
+                        <button class="btn btn-primary" onclick="qml_remove_style('{% url "qgis_server:remove-qml" layername=resource.name style_name=style.name %}')">{% trans "Remove Style" %}</button>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% if alert %}
+    <div class="alert {{ alert_class }}">
+        {{ alert_message }}
+        {% if alert_class == 'alert-success' %}
+            <br />
+            <a href="#" onclick="location.reload(true); return false;">{% trans "Reload to see changes" %}</a>
+        {% endif %}
+    </div>
     {% endif %}
-    <button type="submit" class="btn btn-primary">{% trans "Upload" %}</button>
-</form>
+    <div id="style-add-form">
+        <form id="qgis-server-style-add-form" method="post" action="{% url "qgis_server:upload-qml" layername=resource.name %}" enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ style_upload_form|as_bootstrap }}
+            <button type="submit" class="btn btn-primary">{% trans "Upload" %}</button>
+        </form>
+    </div>
+    <script type="text/javascript">
+        function qml_remove_style(delete_url) {
+            $.ajax({
+                url: delete_url,
+                type: 'DELETE',
+                success: function (data) {
+                    $("#qgis-server-style-edit .modal-body").html(data);
+                    $(document).ready(function() {
+                        $("#qgis-server-style-add-form").on('submit', edit_style_on_submit);
+                    });
+                }
+            });
+        }
+
+        function qml_set_default_style(set_default_url) {
+            $.ajax({
+                url: set_default_url,
+                type: 'POST',
+                success: function (data) {
+                    $("#qgis-server-style-edit .modal-body").html(data);
+                    $(document).ready(function() {
+                        $("#qgis-server-style-add-form").on('submit', edit_style_on_submit);
+                    });
+                }
+            });
+        }
+    </script>
 {% endif %}

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -155,13 +155,12 @@ class HelperTest(LiveServerTestCase):
 
         # it has to contains qgis tags
         style_xml = etree.fromstring(response.content)
-        for child in style_xml:
-            self.assertTrue('qgis' in child.tag)
+        self.assertTrue('qgis' in style_xml.tag)
 
         # Add new style
         # change default style slightly
         self.assertTrue('WhiteToBlack' not in response.content)
-        self.assertInHTML('BlackToWhite', response.content)
+        self.assertTrue('BlackToWhite' in response.content)
         new_style_xml = etree.fromstring(
             response.content.replace('BlackToWhite', 'WhiteToBlack'))
         new_xml_content = etree.tostring(new_style_xml, pretty_print=True)
@@ -191,7 +190,7 @@ class HelperTest(LiveServerTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('Content-Type'), 'text/xml')
-        self.assertInHTML('WhiteToBlack', response.content)
+        self.assertTrue('WhiteToBlack' in response.content)
 
         # Set default style
         style_url = style_set_default_url(

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -117,7 +117,7 @@ class HelperTest(LiveServerTestCase):
             'WIDTH': '256',
             'HEIGHT': '256',
             'LAYERS': 'test_grid',
-            'STYLES': 'default',
+            'STYLE': 'default',
             'FORMAT': 'image/png',
             'TRANSPARENT': 'true',
             'DPI': '96',

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -22,6 +22,9 @@ import urlparse
 import unittest
 from imghdr import what
 
+from geonode.qgis_server.models import QGISServerLayer
+from lxml import etree
+
 import gisdata
 import shutil
 
@@ -35,7 +38,9 @@ from geonode import qgis_server
 from geonode.decorators import on_ogc_backend
 from geonode.layers.utils import file_upload
 from geonode.qgis_server.helpers import validate_django_settings, \
-    transform_layer_bbox, qgis_server_endpoint, tile_url_format, tile_url
+    transform_layer_bbox, qgis_server_endpoint, tile_url_format, tile_url, \
+    style_get_url, style_add_url, style_list, style_set_default_url, \
+    style_remove_url
 
 
 class HelperTest(LiveServerTestCase):
@@ -131,6 +136,81 @@ class HelperTest(LiveServerTestCase):
         self.assertEqual(response.headers.get('Content-Type'), 'image/png')
         self.assertEqual(what('', h=response.content), 'png')
 
+        uploaded.delete()
+
+    @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
+    def test_style_management_url(self):
+        """Test QGIS Server style management url construction."""
+        filename = os.path.join(gisdata.GOOD_DATA, 'raster/test_grid.tif')
+        uploaded = file_upload(filename)
+
+        # Get default style
+        # There will always be a default style when uploading a layer
+        style_url = style_get_url(uploaded, 'default', internal=True)
+
+        response = requests.get(style_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('Content-Type'), 'text/xml')
+
+        # it has to contains qgis tags
+        style_xml = etree.fromstring(response.content)
+        for child in style_xml:
+            self.assertTrue('qgis' in child.tag)
+
+        # Add new style
+        # change default style slightly
+        self.assertTrue('WhiteToBlack' not in response.content)
+        self.assertInHTML('BlackToWhite', response.content)
+        new_style_xml = etree.fromstring(
+            response.content.replace('BlackToWhite', 'WhiteToBlack'))
+        new_xml_content = etree.tostring(new_style_xml, pretty_print=True)
+
+        # save it to qml file, accessible by qgis server
+        qgis_layer = QGISServerLayer.objects.get(layer=uploaded)
+        with open(qgis_layer.qml_path, mode='w') as f:
+            f.write(new_xml_content)
+
+        style_url = style_add_url(uploaded, 'new_style', internal=True)
+
+        response = requests.get(style_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'OK')
+
+        # Get style list
+        qml_styles = style_list(uploaded, internal=False)
+        expected_style_names = ['default', 'new_style']
+        actual_style_names = [s.name for s in qml_styles]
+        self.assertEqual(set(expected_style_names), set(actual_style_names))
+
+        # Get new style
+        style_url = style_get_url(uploaded, 'new_style', internal=True)
+
+        response = requests.get(style_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('Content-Type'), 'text/xml')
+        self.assertInHTML('WhiteToBlack', response.content)
+
+        # Set default style
+        style_url = style_set_default_url(
+            uploaded, 'new_style', internal=True)
+
+        response = requests.get(style_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'OK')
+
+        # Remove style
+        style_url = style_remove_url(uploaded, 'new_style', internal=True)
+
+        response = requests.get(style_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'OK')
+
+        # Cleanup
         uploaded.delete()
 
     @on_ogc_backend(qgis_server.BACKEND_PACKAGE)

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -140,10 +140,25 @@ class QGISServerViewsTest(LiveServerTestCase):
         self.assertEqual(response.status_code, 404)
 
         # QML Styles
+        # Request list of styles
         response = self.client.get(
             reverse('qgis_server:download-qml', kwargs=params))
-        self.assertEqual(response.status_code, 404)
-        # TODO: Upload qml
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('Content-Type'), 'application/json')
+        # Should return a default style list
+        actual_result = json.loads(response.content)
+        actual_result = [s['name'] for s in actual_result]
+        expected_result = ['default']
+        self.assertEqual(set(expected_result), set(actual_result))
+
+        # Get single styles
+        response = self.client.get(
+            reverse('qgis_server:download-qml', kwargs={
+                'layername': params['layername'],
+                'style_name': 'default'
+            }))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('Content-Type'), 'text/xml')
 
         # Set thumbnail from viewed bbox
         response = self.client.get(
@@ -243,7 +258,7 @@ class QGISServerViewsTest(LiveServerTestCase):
 
         # Check get capabilities using helper returns the same thing
         response = requests.get(wms_get_capabilities_url(
-            uploaded, internal=True))
+            uploaded, internal=False))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(get_capabilities_content, response.content)
 

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -24,6 +24,8 @@ import os
 import urlparse
 import zipfile
 from imghdr import what
+
+import requests
 from lxml import etree
 
 import gisdata
@@ -37,6 +39,7 @@ from geonode import qgis_server
 from geonode.decorators import on_ogc_backend
 from geonode.layers.utils import file_upload
 from geonode.maps.models import Map
+from geonode.qgis_server.helpers import wms_get_capabilities_url, style_list
 
 
 class DefaultViewsTest(TestCase):
@@ -169,7 +172,7 @@ class QGISServerViewsTest(LiveServerTestCase):
         # OGC Server specific for THE layer
         query_string = {
             'SERVICE': 'WMS',
-            'VERSION': '1.3.3',
+            'VERSION': '1.3.0',
             'REQUEST': 'GetLegendGraphics',
             'FORMAT': 'image/png',
             'LAYERS': uploaded.name,
@@ -184,7 +187,7 @@ class QGISServerViewsTest(LiveServerTestCase):
         # GetLegendGraphics is a shortcut when using the main OGC server.
         query_string = {
             'SERVICE': 'WMS',
-            'VERSION': '1.3.3',
+            'VERSION': '1.3.0',
             'REQUEST': 'GetLegendGraphics',
             'FORMAT': 'image/png',
             'LAYERS': uploaded.name,
@@ -198,7 +201,7 @@ class QGISServerViewsTest(LiveServerTestCase):
         # WMS GetCapabilities
         query_string = {
             'SERVICE': 'WMS',
-            'VERSION': '1.3.3',
+            'VERSION': '1.3.0',
             'REQUEST': 'GetCapabilities'
         }
 
@@ -212,8 +215,10 @@ class QGISServerViewsTest(LiveServerTestCase):
 
         response = self.client.get(
             reverse('qgis_server:request'), query_string)
-        self.assertEqual(response.status_code, 200, response.content)
+        get_capabilities_content = response.content
+
         # Check xml content
+        self.assertEqual(response.status_code, 200, response.content)
         root = etree.fromstring(response.content)
         layer_xml = root.xpath(
             'wms:Capability/wms:Layer/wms:Layer/wms:Name',
@@ -236,10 +241,17 @@ class QGISServerViewsTest(LiveServerTestCase):
         self.assertEqual(response.get('Content-Type'), 'image/png')
         self.assertEqual(what('', h=response.content), 'png')
 
+        # Check get capabilities using helper returns the same thing
+        response = requests.get(wms_get_capabilities_url(
+            uploaded, internal=True))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(get_capabilities_content, response.content)
+
+
         # WMS GetMap
         query_string = {
             'SERVICE': 'WMS',
-            'VERSION': '1.3.3',
+            'VERSION': '1.3.0',
             'REQUEST': 'GetMap',
             'FORMAT': 'image/png',
             'LAYERS': uploaded.name,
@@ -259,6 +271,20 @@ class QGISServerViewsTest(LiveServerTestCase):
         uploaded.delete()
         vector_layer.delete()
 
+
+class QGISServerStyleManagerTest(LiveServerTestCase):
+
+    def setUp(self):
+        call_command('loaddata', 'people_data', verbosity=0)
+
+    @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
+    def test_list_style(self):
+        """Test querying list of styles from QGIS Server."""
+        filename = os.path.join(gisdata.GOOD_DATA, 'raster/test_grid.tif')
+        layer = file_upload(filename)
+        """:type: geonode.layers.models.Layer"""
+
+        actual_list_style = style_list(layer, internal=False)
 
 class ThumbnailGenerationTest(LiveServerTestCase):
 

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -247,7 +247,6 @@ class QGISServerViewsTest(LiveServerTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(get_capabilities_content, response.content)
 
-
         # WMS GetMap
         query_string = {
             'SERVICE': 'WMS',
@@ -285,6 +284,14 @@ class QGISServerStyleManagerTest(LiveServerTestCase):
         """:type: geonode.layers.models.Layer"""
 
         actual_list_style = style_list(layer, internal=False)
+        expected_list_style = ['default']
+
+        # There will be a default style
+        self.assertEqual(
+            set(expected_list_style),
+            set([style.name for style in actual_list_style])
+        )
+
 
 class ThumbnailGenerationTest(LiveServerTestCase):
 

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -30,7 +30,7 @@ from geonode.qgis_server.views import (
     qgis_server_pdf,
     qgis_server_map_print,
     geotiff,
-    qml_style, set_thumbnail)
+    qml_style, set_thumbnail, default_qml_style)
 
 
 urlpatterns = patterns(
@@ -98,14 +98,19 @@ urlpatterns = patterns(
         name='map-print'
     ),
     url(
-        r'^style/(?P<layername>[^/]*)/edit$',
+        r'^style/(?P<layername>[^/]*)(?:/(?P<style_name>[^/]*))?/edit$',
         qml_style,
-        name='update-qml'
+        name='upload-qml'
     ),
     url(
-        r'^style/(?P<layername>[^/]*)$',
+        r'^style/(?P<layername>[^/]*)(?:/(?P<style_name>[^/]*))?$',
         qml_style,
         name='download-qml'
+    ),
+    url(
+        r'^style/(?P<layername>[^/]*)/(?P<style_name>[^/]*)/default$',
+        default_qml_style,
+        name='default-qml'
     ),
     url(
         r'^thumbnail/set/(?P<layername>[^/]*)$',

--- a/geonode/qgis_server/urls.py
+++ b/geonode/qgis_server/urls.py
@@ -53,6 +53,24 @@ urlpatterns = patterns(
     ),
     url(
         r'^tiles/'
+        r'(?P<layername>[^/]*)/'
+        r'(?P<style>[^/]*)/'
+        r'(?P<z>[0-9]*)/'
+        r'(?P<x>[0-9]*)/'
+        r'(?P<y>[0-9]*).png$',
+        tile,
+        name='tile'
+    ),
+    url(
+        r'^tiles/'
+        r'(?P<layername>[^/]*)/'
+        r'(?P<style>[^/]*)/'
+        r'\{z\}/\{x\}/\{y\}.png$',
+        tile_404,
+        name='tile'
+    ),
+    url(
+        r'^tiles/'
         r'(?P<layername>[^/]*)/\{z\}/\{x\}/\{y\}.png$',
         tile_404,
         name='tile'
@@ -63,7 +81,14 @@ urlpatterns = patterns(
         name='geotiff'
     ),
     url(
-        r'^legend/(?P<layername>[\w]*)(?:/(?P<layertitle>[\w]*))?$',
+        r'^legend/(?P<layername>[\w]*)/'
+        r'(?P<style>[\w]*)/'
+        r'(?:/(?P<layertitle>(True|False)))?$',
+        legend,
+        name='legend'
+    ),
+    url(
+        r'^legend/(?P<layername>[\w]*)(?:/(?P<layertitle>(True|False)))?$',
         legend,
         name='legend'
     ),
@@ -106,6 +131,11 @@ urlpatterns = patterns(
         r'^style/(?P<layername>[^/]*)(?:/(?P<style_name>[^/]*))?$',
         qml_style,
         name='download-qml'
+    ),
+    url(
+        r'^style/(?P<layername>[^/]*)(?:/(?P<style_name>[^/]*))?$',
+        qml_style,
+        name='remove-qml'
     ),
     url(
         r'^style/(?P<layername>[^/]*)/(?P<style_name>[^/]*)/default$',

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -27,26 +27,30 @@ import zipfile
 from imghdr import what as image_format
 
 import re
+
+import datetime
 import requests
 from django.conf import settings
 from django.core.files import File
 from django.core.urlresolvers import reverse
+from django.forms.models import model_to_dict
 from django.http import HttpResponse, Http404
 from django.http.response import (
     HttpResponseBadRequest,
     HttpResponseServerError)
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils.translation import ugettext as _
 
-from geonode.layers.models import Layer
+from geonode.layers.models import Layer, LayerFile
 from geonode.qgis_server.forms import QGISLayerStyleUploadForm
 from geonode.qgis_server.helpers import (
     tile_url_format,
     create_qgis_project,
     legend_url,
     tile_url,
-    qgis_server_endpoint)
+    qgis_server_endpoint, style_get_url, style_list, style_add_url,
+    style_remove_url, style_set_default_url)
 from geonode.qgis_server.models import QGISServerLayer
 from geonode.qgis_server.tasks.update import (
     create_qgis_server_thumbnail,
@@ -328,6 +332,15 @@ def qgis_server_request(request):
             layer = get_object_or_404(Layer, name=layer_name)
             return legend(request, layername=layer.name)
 
+    # Validation for STYLEMANAGER service
+    if params.get('SERVICE') == 'STYLEMANAGER':
+        project_param = params.get('PROJECT')
+        layer_name = params.get('LAYER')
+        if not project_param and layer_name:
+            layer = get_object_or_404(Layer, name=layer_name)
+            qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
+            params['PROJECT'] = qgis_layer.qgis_project_path
+
     # if not shortcut, we forward any request to internal QGIS Server
     qgis_server_url = qgis_server_endpoint(internal=True)
     response = requests.get(qgis_server_url, params)
@@ -406,31 +419,32 @@ def qgis_server_map_print(request):
         json.dumps(temp), content_type="application/json")
 
 
-def qml_style(request, layername):
+def qml_style(request, layername, style_name=None):
     """Update/Retrieve QML style of a given QGIS Layer.
 
     :param layername: The layer name in Geonode.
     :type layername: basestring
-    :return:
+
+    :param style_name: The style name recognized by QGIS Server
+    :type style_name: str
     """
     layer = get_object_or_404(Layer, name=layername)
 
     if request.method == 'GET':
-        # Take QML file from QGIS Server directory
-        qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
-        qml_path = qgis_layer.qml_path
 
-        if not os.path.exists(qml_path):
-            raise Http404(
-                'This layer does not have current default QML style.')
+        # Request QML from QGIS server
+        if not style_name:
+            # If no style name provided, then it is a List request
+            styles_obj = style_list(layer, internal=False)
+            styles_dict = [model_to_dict(s) for s in styles_obj]
 
-        response = HttpResponse(
-            open(qml_path), content_type="application/text")
-        # ..and correct content-disposition
-        response['Content-Disposition'] = (
-            'attachment; filename={filename}'.format(
-                filename=os.path.basename(qml_path)))
-        return response
+            response = HttpResponse(
+                json.dumps(styles_dict), content_type='application/json')
+            return response
+
+        # Return XML file of the style
+        style_url = style_get_url(layer, style_name, internal=False)
+        return redirect(style_url)
     elif request.method == 'POST':
 
         # For people who uses API request
@@ -439,6 +453,8 @@ def qml_style(request, layername):
             return HttpResponse(
                 'User does not have permission to change QML style.',
                 status=401)
+
+        # Request about adding new QML style
 
         form = QGISLayerStyleUploadForm(request.POST, request.FILES)
 
@@ -458,56 +474,40 @@ def qml_style(request, layername):
             # update qml in uploaded media folder
             # check upload session, is qml file exists?
             layerfile_set = layer.upload_session.layerfile_set
-            qml_layer_file, created = layerfile_set.get_or_create(name='qml')
-
             try:
-                qml_path = qml_layer_file.file.path
-                content = uploaded_qml.read()
-                with open(qml_path, mode='w') as f:
-                    f.write(content)
-            except ValueError:
-                layer_base_path, __ = layer.get_base_file()
-                layer_prefix, __ = os.path.splitext(
-                    layer_base_path.file.path)
-                qml_path = '{prefix}.qml'.format(prefix=layer_prefix)
-
-                content = uploaded_qml.read()
-
-                qml_layer_file.file = File(
-                    uploaded_qml,
-                    name=os.path.basename(qml_path))
-                qml_layer_file.base = False
-                qml_layer_file.upload_session = layer.upload_session
-                qml_layer_file.save()
+                qml_layer_file = layerfile_set.get(name='qml')
+                # if it is exists, we need to delete it, because it won't be
+                # managed by geonode
+                qml_layer_file.delete()
+            except LayerFile.DoesNotExist:
+                pass
 
             # update qml in QGIS Layer folder
+            content = uploaded_qml.read()
             qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
 
             with open(qgis_layer.qml_path, mode='w') as f:
                 f.write(content)
 
-            # update QGIS Project files
-            response = create_qgis_project(
-                layer,
-                qgis_layer.qgis_project_path,
-                overwrite=True,
-                internal=True)
-            if not response.content == 'OK':
+            # construct URL to post new QML
+            style_name = request.POST['name']
+            if not style_name:
+                # Assign default name
+                name_format = 'style_%Y%m%d%H%M%S'
+                current_time = datetime.datetime.utcnow()
+                style_name = current_time.strftime(name_format)
+
+            # Add new style
+            style_url = style_add_url(layer, style_name)
+
+            response = requests.get(style_url)
+
+            if not (response.status_code == 200 and response.content == 'OK'):
                 return HttpResponseServerError(
-                    'Failed to create new QGIS Project.'
+                    'Failed to create new Style.'
                     'Error: {0}'.format(response.content))
 
-            # Because we update a style, we need to recache
-            qgis_tiles_directory = settings.QGIS_SERVER_CONFIG['tiles_directory']
-
-            layer_tiles_path = os.path.join(
-                qgis_tiles_directory, qgis_layer.qgis_layer_name)
-
-            try:
-                shutil.rmtree(layer_tiles_path)
-            except:
-                pass
-
+            # We succeeded on adding new style
             return TemplateResponse(
                 request,
                 'qgis_server/forms/qml_style.html',
@@ -521,8 +521,71 @@ def qml_style(request, layername):
         except Exception as e:
             logger.exception(e)
             return HttpResponseServerError()
+    elif request.method == 'DELETE':
+        # Request to delete particular QML Style
+
+        if not style_name:
+            # Style name should exists
+            return HttpResponseBadRequest('Style name not provided.')
+
+        style_url = style_remove_url(layer, style_name)
+
+        response = requests.get(style_url)
+
+        if not (response.status_code == 200 and response.content == 'OK'):
+            return HttpResponseServerError(
+                'Failed to remove Style.'
+                'Error: {0}'.format(response.content))
+
+        # Successfully removed styles
+        # TODO: Handle when default style is deleted.
+        # We have to know the default style first
+
+        # TODO: Handle removing tile-style cache
+
+        retval = {
+            'success': True,
+            'name': style_name
+        }
+
+        return HttpResponse(
+            json.dumps(retval), content_type='application/json')
 
     return HttpResponseBadRequest()
+
+
+def default_qml_style(request, layername, style_name):
+    """Set default style used by layer.
+
+    :param layername: The layer name in Geonode.
+    :type layername: basestring
+
+    :param style_name: The style name recognized by QGIS Server
+    :type style_name: str
+    """
+    if request.method != 'POST':
+        # TODO: Handle querying default style name request
+        return HttpResponseBadRequest()
+
+    layer = get_object_or_404(Layer, name=layername)
+    style_url = style_set_default_url(layer, style_name)
+
+    response = requests.get(style_url)
+
+    if not (response.status_code == 200 and response.content == 'OK'):
+        return HttpResponseServerError(
+            'Failed to change default Style.'
+            'Error: {0}'.format(response.content))
+
+    # TODO: Handle removing default tile-style cache and thumbnail
+
+    retval = {
+        'success': True,
+        'name': style_name
+    }
+
+    return HttpResponse(
+        json.dumps(retval), content_type='application/json')
 
 
 def set_thumbnail(request, layername):

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -29,6 +29,7 @@ import re
 
 import datetime
 import requests
+import shutil
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.forms.models import model_to_dict
@@ -36,7 +37,7 @@ from django.http import HttpResponse, Http404
 from django.http.response import (
     HttpResponseBadRequest,
     HttpResponseServerError)
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils.translation import ugettext as _
 
@@ -105,7 +106,7 @@ def download_zip(request, layername):
     return resp
 
 
-def legend(request, layername, layertitle=False):
+def legend(request, layername, layertitle=False, style=None):
     """Get the legend from a layer.
 
     :param layername: The layer name in Geonode.
@@ -114,20 +115,29 @@ def legend(request, layername, layertitle=False):
     :param layertitle: Add the layer title in the legend. Default to False.
     :type layertitle: bool
 
+    :param style: Layer style to choose
+    :type style: str
+
     :return: The HTTPResponse with a PNG.
     """
     layer = get_object_or_404(Layer, name=layername)
     qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
 
+    # get default style name
+    if not style:
+        # generate style cache
+        style_list(layer)
+        style = qgis_layer.default_style.name
+
     legend_path = QGIS_SERVER_CONFIG['legend_path']
-    legend_filename = legend_path % qgis_layer.qgis_layer_name
+    legend_filename = legend_path % (qgis_layer.qgis_layer_name, style)
 
     if not os.path.exists(legend_filename):
 
         if not os.path.exists(os.path.dirname(legend_filename)):
             os.makedirs(os.path.dirname(legend_filename))
 
-        url = legend_url(layer, layertitle, internal=True)
+        url = legend_url(layer, layertitle, style=style, internal=True)
 
         result = cache_request.delay(url, legend_filename)
 
@@ -170,7 +180,7 @@ def tile_404(request, layername):
         status=404).render()
 
 
-def tile(request, layername, z, x, y):
+def tile(request, layername, z, x, y, style=None):
     """Get the tile from a layer.
 
     :param layername: The layer name in Geonode.
@@ -185,6 +195,9 @@ def tile(request, layername, z, x, y):
     :param y: TMS coordinate, latitude parameter
     :type y: int, str
 
+    :param style: Layer style to choose
+    :type style: str
+
     :return: The HTTPResponse with a PNG.
     """
     x = int(x)
@@ -194,8 +207,14 @@ def tile(request, layername, z, x, y):
     layer = get_object_or_404(Layer, name=layername)
     qgis_layer = get_object_or_404(QGISServerLayer, layer=layer)
 
+    # get default style name
+    if not style:
+        # generate style cache
+        style_list(layer)
+        style = qgis_layer.default_style.name
+
     tile_path = QGIS_SERVER_CONFIG['tile_path']
-    tile_filename = tile_path % (qgis_layer.qgis_layer_name, z, x, y)
+    tile_filename = tile_path % (qgis_layer.qgis_layer_name, style, z, x, y)
 
     if not os.path.exists(tile_filename):
 
@@ -203,7 +222,7 @@ def tile(request, layername, z, x, y):
             os.makedirs(os.path.dirname(tile_filename))
 
         # Use internal url
-        url = tile_url(layer, z, x, y, internal=True)
+        url = tile_url(layer, z, x, y, style=style, internal=True)
 
         result = cache_request.delay(url, tile_filename)
 
@@ -435,13 +454,37 @@ def qml_style(request, layername, style_name=None):
             styles_obj = style_list(layer, internal=False)
             styles_dict = [model_to_dict(s) for s in styles_obj]
 
+            # If no style returned by GetCapabilities, this is a bug in QGIS
+            # Attempt to generate default style name
+            if not styles_dict:
+                style_url = style_get_url(layer, 'default')
+                response = requests.get(style_url)
+                if response.status_code == 200:
+                    style_url = style_add_url(layer, 'default')
+                    with open(layer.qgis_layer.qml_path, 'w') as f:
+                        f.write(response.content)
+                    response = requests.get(style_url)
+                    if response.status_code == 200:
+                        styles_obj = style_list(layer, internal=False)
+                        styles_dict = [model_to_dict(s) for s in styles_obj]
+
             response = HttpResponse(
                 json.dumps(styles_dict), content_type='application/json')
             return response
 
         # Return XML file of the style
         style_url = style_get_url(layer, style_name, internal=False)
-        return redirect(style_url)
+        response = requests.get(style_url)
+        if response.status_code == 200:
+            response = HttpResponse(
+                response.content, content_type='text/xml')
+            response[
+                'Content-Disposition'] = 'attachment; filename=%s.qml' % (
+                style_name, )
+        else:
+            response = HttpResponse(
+                response.content, status=response.status_code)
+        return response
     elif request.method == 'POST':
 
         # For people who uses API request
@@ -488,6 +531,7 @@ def qml_style(request, layername, style_name=None):
 
             # construct URL to post new QML
             style_name = request.POST['name']
+            style_title = request.POST['title']
             if not style_name:
                 # Assign default name
                 name_format = 'style_%Y%m%d%H%M%S'
@@ -500,18 +544,38 @@ def qml_style(request, layername, style_name=None):
             response = requests.get(style_url)
 
             if not (response.status_code == 200 and response.content == 'OK'):
-                return HttpResponseServerError(
-                    'Failed to create new Style.'
-                    'Error: {0}'.format(response.content))
+                style_list(layer, internal=False)
+                return TemplateResponse(
+                    request,
+                    'qgis_server/forms/qml_style.html',
+                    {
+                        'resource': layer,
+                        'style_upload_form': QGISLayerStyleUploadForm(),
+                        'alert': True,
+                        'alert_message': response.content,
+                        'alert_class': 'alert-danger'
+                    },
+                    status=200).render()
 
             # We succeeded on adding new style
+
+            # Refresh style models
+            style_list(layer, internal=False)
+            qgis_style = layer.qgis_layer.styles.get(name=style_name)
+            qgis_style.title = style_title
+            qgis_style.save()
+
+            alert_message = 'Successfully add style %s' % style_name
+
             return TemplateResponse(
                 request,
                 'qgis_server/forms/qml_style.html',
                 {
                     'resource': layer,
                     'style_upload_form': form,
-                    'success': True
+                    'alert': True,
+                    'alert_class': 'alert-success',
+                    'alert_message': alert_message
                 },
                 status=200).render()
 
@@ -525,28 +589,52 @@ def qml_style(request, layername, style_name=None):
             # Style name should exists
             return HttpResponseBadRequest('Style name not provided.')
 
+        # Handle removing tile-style cache
+        try:
+            style = layer.qgis_layer.styles.get(name=style_name)
+            shutil.rmtree(style.style_tile_cache_path)
+        except OSError:
+            pass
+
         style_url = style_remove_url(layer, style_name)
 
         response = requests.get(style_url)
 
         if not (response.status_code == 200 and response.content == 'OK'):
-            return HttpResponseServerError(
-                'Failed to remove Style.'
-                'Error: {0}'.format(response.content))
+            alert_message = response.content
+            if 'NAME is NOT an existing style.' in response.content:
+                alert_message = '%s is not an existing style' % style_name
+            style_list(layer, internal=False)
+            return TemplateResponse(
+                request,
+                'qgis_server/forms/qml_style.html',
+                {
+                    'resource': layer,
+                    'style_upload_form': QGISLayerStyleUploadForm(),
+                    'alert': True,
+                    'alert_message': alert_message,
+                    'alert_class': 'alert-danger'
+                },
+                status=200).render()
 
         # Successfully removed styles
-        # TODO: Handle when default style is deleted.
-        # We have to know the default style first
+        # Handle when default style is deleted.
+        # Will be handled by style_list method
+        style_list(layer, internal=False)
 
-        # TODO: Handle removing tile-style cache
+        alert_message = 'Successfully deleted style %s' % style_name
 
-        retval = {
-            'success': True,
-            'name': style_name
-        }
-
-        return HttpResponse(
-            json.dumps(retval), content_type='application/json')
+        return TemplateResponse(
+            request,
+            'qgis_server/forms/qml_style.html',
+            {
+                'resource': layer,
+                'style_upload_form': QGISLayerStyleUploadForm(),
+                'alert': True,
+                'alert_message': alert_message,
+                'alert_class': 'alert-success'
+            },
+            status=200).render()
 
     return HttpResponseBadRequest()
 
@@ -560,29 +648,48 @@ def default_qml_style(request, layername, style_name):
     :param style_name: The style name recognized by QGIS Server
     :type style_name: str
     """
-    if request.method != 'POST':
-        # TODO: Handle querying default style name request
-        return HttpResponseBadRequest()
-
     layer = get_object_or_404(Layer, name=layername)
-    style_url = style_set_default_url(layer, style_name)
 
-    response = requests.get(style_url)
+    if request.method == 'GET':
+        # Handle querying default style name request
+        default_style = layer.qgis_layer.default_style
+        retval = {
+            'name': default_style.name,
+            'title': default_style.title,
+            'style_url': default_style.style_url
+        }
+        return HttpResponse(
+            json.dumps(retval), content_type='application/json')
+    elif request.method == 'POST':
+        style_url = style_set_default_url(layer, style_name)
 
-    if not (response.status_code == 200 and response.content == 'OK'):
-        return HttpResponseServerError(
-            'Failed to change default Style.'
-            'Error: {0}'.format(response.content))
+        response = requests.get(style_url)
 
-    # TODO: Handle removing default tile-style cache and thumbnail
+        if not (response.status_code == 200 and response.content == 'OK'):
+            return HttpResponseServerError(
+                'Failed to change default Style.'
+                'Error: {0}'.format(response.content))
 
-    retval = {
-        'success': True,
-        'name': style_name
-    }
+        # Succesfully change default style
+        # Synchronize models
+        style = layer.qgis_layer.styles.get(name=style_name)
+        qgis_layer = layer.qgis_layer
+        qgis_layer.default_style = style
+        qgis_layer.save()
 
-    return HttpResponse(
-        json.dumps(retval), content_type='application/json')
+        alert_message = 'Successfully changed default style %s' % style_name
+
+        return TemplateResponse(
+            request,
+            'qgis_server/forms/qml_style.html',
+            {
+                'resource': layer,
+                'style_upload_form': QGISLayerStyleUploadForm(),
+                'alert': True,
+                'alert_message': alert_message,
+                'alert_class': 'alert-success'
+            },
+            status=200).render()
 
 
 def set_thumbnail(request, layername):

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -126,7 +126,10 @@ def legend(request, layername, layertitle=False, style=None):
     # get default style name
     if not style:
         # generate style cache
-        style_list(layer)
+        if not qgis_layer.default_style:
+            style_list(layer, internal=False)
+            # refresh values
+            qgis_layer.refresh_from_db()
         style = qgis_layer.default_style.name
 
     legend_path = QGIS_SERVER_CONFIG['legend_path']
@@ -210,7 +213,10 @@ def tile(request, layername, z, x, y, style=None):
     # get default style name
     if not style:
         # generate style cache
-        style_list(layer)
+        if not qgis_layer.default_style:
+            style_list(layer, internal=False)
+            # refresh values
+            qgis_layer.refresh_from_db()
         style = qgis_layer.default_style.name
 
     tile_path = QGIS_SERVER_CONFIG['tile_path']

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -22,7 +22,6 @@ import StringIO
 import json
 import logging
 import os
-import shutil
 import zipfile
 from imghdr import what as image_format
 
@@ -31,7 +30,6 @@ import re
 import datetime
 import requests
 from django.conf import settings
-from django.core.files import File
 from django.core.urlresolvers import reverse
 from django.forms.models import model_to_dict
 from django.http import HttpResponse, Http404
@@ -46,7 +44,6 @@ from geonode.layers.models import Layer, LayerFile
 from geonode.qgis_server.forms import QGISLayerStyleUploadForm
 from geonode.qgis_server.helpers import (
     tile_url_format,
-    create_qgis_project,
     legend_url,
     tile_url,
     qgis_server_endpoint, style_get_url, style_list, style_add_url,

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -665,10 +665,20 @@ class GeoNodeMapTest(TestCase):
         self.assertEquals(response.context['is_featuretype'], True)
 
         # test replace a vector with a raster
+        post_permissions = {
+            'users': {
+                'AnonymousUser': [
+                    'view_resourcebase', 'download_resourcebase']
+            },
+            'groups': {}
+        }
+        post_data = {
+            'base_file': open(
+                raster_file, 'rb'),
+            'permissions': json.dumps(post_permissions)
+        }
         response = self.client.post(
-            vector_replace_url, {
-                'base_file': open(
-                    raster_file, 'rb')})
+            vector_replace_url, post_data)
         # TODO: This should really return a 400 series error with the json dict
         self.assertEquals(response.status_code, 400)
         response_dict = json.loads(response.content)
@@ -689,7 +699,8 @@ class GeoNodeMapTest(TestCase):
             {'base_file': layer_base,
              'dbf_file': layer_dbf,
              'shx_file': layer_shx,
-             'prj_file': layer_prj
+             'prj_file': layer_prj,
+             'permissions': json.dumps(post_permissions)
              })
         self.assertEquals(response.status_code, 200)
         response_dict = json.loads(response.content)
@@ -714,7 +725,8 @@ class GeoNodeMapTest(TestCase):
             {'base_file': layer_base,
              'dbf_file': layer_dbf,
              'shx_file': layer_shx,
-             'prj_file': layer_prj
+             'prj_file': layer_prj,
+             'permissions': json.dumps(post_permissions)
              })
         self.assertEquals(response.status_code, 401)
 

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -564,7 +564,7 @@ class GeoNodeMapTest(TestCase):
         shp_layer = file_upload(shp_file)
 
         # get layer and QGIS Server Layer object
-        qgis_layer = shp_layer.qgisserverlayer
+        qgis_layer = shp_layer.qgis_layer
         base_path = qgis_layer.base_layer_path
         base_name, _ = os.path.splitext(base_path)
 


### PR DESCRIPTION
Related with #149 
Work in progress:

TODO:

- [ ] Add Unified Geonode Layers style query for Geoserver and QGIS Server
- [ ] Add Unified Geonode API for querying style.
- [x] Support QML Style for API (QGIS Server Backend)
- [ ] Support SLD Style for API (Geoserver Backend)
- [x] Implement style query to QGIS Server
- [x] Add unittest for style management query
- [x] Refactor style management on Layer Details.
- [x] Refactor view function for upload/download QML Style
- [x] Implement UI for style management for QGIS Server Backend