### PR TITLE
fix wrong zoom

### DIFF
--- a/geonode/maps/templates/leaflet_maps/map_view.html
+++ b/geonode/maps/templates/leaflet_maps/map_view.html
@@ -61,6 +61,7 @@
                     <div>
                         <ul id="layer-list">
                         </ul>
+                        <span id="hidden-layer-list"></span>
                     </div>
                     <h4>Background layers</h4>
                     <div>
@@ -218,7 +219,15 @@
             // Remove layer from map layer list
             remove("li_" + button.value);
             // Remove from list overlay layers
-            remove_from_list(all_layers, button.value);
+            // This statement seems to be bug, so being commented out
+            //remove_from_list(all_layers, button.value);
+            // Remove hidden layer
+            var hidden_layers = $("#hidden-layer-list > input");
+            hidden_layers.each(function() {
+                if (this.id == "hidden_" + button.value) {
+                    this.remove();
+                }
+            });
 
             // Show from available layer
             document.getElementById("option_" + button.value).style.display = 'block';
@@ -231,11 +240,16 @@
             }
         }
 
+        function compare_bounds(bound1, bound2) {
+            return [
+                Math.max(bound1[0], bound2[0]),
+                Math.min(bound1[1], bound2[1]),
+                Math.max(bound1[2], bound2[2]),
+                Math.min(bound1[3], bound2[3]) ]
+        }
+
         function add_layer(layer_typename, visibility, layer_order) {
             visibility = typeof visibility !== 'undefined' ? visibility : true;
-            if (layer_typename in all_layers) {
-                return
-            }
             if (layer_typename in all_layers) {
                 return
             }
@@ -255,12 +269,30 @@
                     var tile_layer = L.tileLayer(layer_url);
                     if (tile_layer != null) {
                         // Set view to new added layer
-                        zoom_to_box(map, [
-                            json['bbox_x0'],
-                            json['bbox_y0'],
-                            json['bbox_x1'],
-                            json['bbox_y1']
-                        ]);
+                        var bounds = [json['bbox_x0'], json['bbox_y0'],
+                            json['bbox_x1'], json['bbox_y1']];
+
+                        // Determine which extent should be used, only uses the widest one
+                        var hidden_layers = $("#hidden-layer-list > input");
+                        if(hidden_layers.length != 0) {
+                            temp_bounds = undefined;
+                            hidden_layers.each(function () {
+                                //temp_bounds has been determined from the previous loop
+                                if(temp_bounds != undefined) {
+                                    bounds = temp_bounds;
+                                }
+                                previous_bounds = $(this).val();
+                                //convert string to float
+                                previous_bounds = previous_bounds.split(",").map(function (elem) {
+                                        return parseFloat(elem);
+                                    });
+                                temp_bounds = compare_bounds(bounds, previous_bounds);
+                            });
+                            // The zoom value will determine how wide the layers will be shown
+                            map.setZoom(5);
+                            bounds = temp_bounds;
+                        }
+                        zoom_to_box(map, bounds);
 
                         // Add to list layer
                         if (visibility) {
@@ -281,6 +313,7 @@
                                     "</li>");
                         }
 
+                        $("#hidden-layer-list").html("<input type='hidden' id='hidden_"+ layer_typename +"' value='"+bounds+"' />");
 
                         // Add to memory
                         var added_layer = {};


### PR DESCRIPTION
fix zooming when two non-intersection layers are selected on create new map page

fix #298

Below is the snapshot.
@NyakudyaA the zoom level would determine how wide the layers can be shown on the map.
There are two illustration at the GIF.
the first illustration shows that two adjacent layers (Malawi and Tanzania) are drawn on the map. 
But, in the second illustration, it would be difficult when the two layers (Malawi and Nepal) have a large distance.
![fixwrongdefaultzoom298](https://user-images.githubusercontent.com/4602383/29077339-11828dce-7c82-11e7-862e-20b4a1eff558.gif)
