### PR TITLE
Fix form errors not shown in style upload

### DIFF
--- a/geonode/layers/templates/layers/layer_leaflet_map.html
+++ b/geonode/layers/templates/layers/layer_leaflet_map.html
@@ -311,6 +311,12 @@
                         $("#qgis-server-style-add-form").on('submit', edit_style_on_submit);
                     });
                 }
+            },
+            error: function(jqXhr, textStatus, errorThrown){
+                $("#qgis-server-style-edit .modal-body").html(jqXhr.responseText);
+                $(document).ready(function() {
+                    $("#qgis-server-style-add-form").on('submit', edit_style_on_submit);
+                });
             }
         });
         return false;


### PR DESCRIPTION
This fix will show form validation for style upload form.
It happens because the error callback does not properly replace the form's html code

Fix #335 