### PR TITLE
duplicate logs QGIS server as logging configuration id done twice.

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -420,8 +420,6 @@ LOGGING = {
             "handlers": ["console"], "level": "ERROR", },
         "geonode": {
             "handlers": ["console"], "level": "ERROR", },
-        "geonode.qgis_server": {
-            "handlers": ["console"], "level": "DEBUG", },
         "gsconfig.catalog": {
             "handlers": ["console"], "level": "ERROR", },
         "owslib": {


### PR DESCRIPTION
duplicate logs QGIS server as logging configuration id done twice. Will ll resolve kartoza/docker-geosafe#98