### PR TITLE
Fix qgis server bound projection

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -339,7 +339,7 @@ def get_resolution(filename):
 
 def get_bbox(filename):
     """Return bbox in the format [xmin,xmax,ymin,ymax]."""
-    from django.contrib.gis.gdal import DataSource
+    from django.contrib.gis.gdal import DataSource, SRSException
     srid = None
     bbox_x0, bbox_y0, bbox_x1, bbox_y1 = None, None, None, None
 
@@ -352,7 +352,13 @@ def get_bbox(filename):
         layer = datasource[0]
         bbox_x0, bbox_y0, bbox_x1, bbox_y1 = layer.extent.tuple
         srs = layer.srs
-        srs.identify_epsg()
+        try:
+            if not srs:
+                raise GeoNodeException('Invalid Projection. Layer is missing CRS!')
+            srs.identify_epsg()
+        except SRSException:
+            pass
+            # raise GeoNodeException('Unsupported SRS.')
         epsg_code = srs.srid
         # can't find epsg code, then check if bbox is within the 4326 boundary
         if epsg_code is None and (x_min <= bbox_x0 <= x_max \

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -351,18 +351,9 @@ def get_bbox(filename):
         datasource = DataSource(filename)
         layer = datasource[0]
         bbox_x0, bbox_y0, bbox_x1, bbox_y1 = layer.extent.tuple
-        # gdal's SourceData seems to be unreliable in determining EPSG code.
-        # obtain EPSG code from a prj file instead
-        prj_path = filename.split(".shp")[0] + ".prj"
-        try:
-            prj_file = open(prj_path, 'r')
-            prj_txt = prj_file.read()
-            prj_file.close()
-        except Exception:
-            raise GeoNodeException("Invalid Projection. Layer is missing CRS!")
-        srs = osr.SpatialReference(wkt=prj_txt)
-        srs.AutoIdentifyEPSG()
-        epsg_code = srs.GetAuthorityCode(None)
+        srs = layer.srs
+        srs.identify_epsg()
+        epsg_code = srs.srid
         # can't find epsg code, then check if bbox is within the 4326 boundary
         if epsg_code is None and (x_min <= bbox_x0 <= x_max \
                                   and  x_min <= bbox_x1 <= x_max \

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -361,9 +361,9 @@ def get_bbox(filename):
             # raise GeoNodeException('Unsupported SRS.')
         epsg_code = srs.srid
         # can't find epsg code, then check if bbox is within the 4326 boundary
-        if epsg_code is None and (x_min <= bbox_x0 <= x_max \
-                                  and  x_min <= bbox_x1 <= x_max \
-                                  and y_min <= bbox_y0 <= y_max \
+        if epsg_code is None and (x_min <= bbox_x0 <= x_max
+                                  and x_min <= bbox_x1 <= x_max
+                                  and y_min <= bbox_y0 <= y_max
                                   and y_min <= bbox_y1 <= y_max):
             # set default epsg code
             epsg_code = '4326'

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -344,10 +344,10 @@ def get_bbox(filename):
     bbox_x0, bbox_y0, bbox_x1, bbox_y1 = None, None, None, None
 
     if is_vector(filename):
-        y_min = -85
-        y_max = 85
+        y_min = -90
+        y_max = 90
         x_min = -180
-        x_max = 85
+        x_max = 180
         datasource = DataSource(filename)
         layer = datasource[0]
         bbox_x0, bbox_y0, bbox_x1, bbox_y1 = layer.extent.tuple
@@ -356,22 +356,25 @@ def get_bbox(filename):
         prj_path = filename.split(".shp")[0] + ".prj"
         try:
             prj_file = open(prj_path, 'r')
+            prj_txt = prj_file.read()
+            prj_file.close()
         except Exception:
             raise GeoNodeException("Invalid Projection. Layer is missing CRS!")
-        prj_txt = prj_file.read()
         srs = osr.SpatialReference(wkt=prj_txt)
         srs.AutoIdentifyEPSG()
         epsg_code = srs.GetAuthorityCode(None)
-        # can't find epsg code, then check if bbox is within the WGS84 boundary
+        # can't find epsg code, then check if bbox is within the 4326 boundary
         if epsg_code is None and (x_min <= bbox_x0 <= x_max \
                                   and  x_min <= bbox_x1 <= x_max \
                                   and y_min <= bbox_y0 <= y_max \
                                   and y_min <= bbox_y1 <= y_max):
             # set default epsg code
             epsg_code = '4326'
-        else:
+        elif epsg_code is None:
             # otherwise, stop the upload process
-            raise GeoNodeException("Invalid Projection. Please use valid EPSG code")
+            raise GeoNodeException(
+                "Invalid Layers. "
+                "Needs an authoritative SRID in its CRS to be accepted")
 
         # eliminate default EPSG srid as it will be added when this function returned
         srid = epsg_code if epsg_code else '4326'

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -362,9 +362,9 @@ def get_bbox(filename):
         epsg_code = srs.srid
         # can't find epsg code, then check if bbox is within the 4326 boundary
         if epsg_code is None and (x_min <= bbox_x0 <= x_max and
-                                    x_min <= bbox_x1 <= x_max and
-                                    y_min <= bbox_y0 <= y_max and
-                                    y_min <= bbox_y1 <= y_max):
+                                  x_min <= bbox_x1 <= x_max and
+                                  y_min <= bbox_y0 <= y_max and
+                                  y_min <= bbox_y1 <= y_max):
             # set default epsg code
             epsg_code = '4326'
         elif epsg_code is None:

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -361,10 +361,10 @@ def get_bbox(filename):
             # raise GeoNodeException('Unsupported SRS.')
         epsg_code = srs.srid
         # can't find epsg code, then check if bbox is within the 4326 boundary
-        if epsg_code is None and (x_min <= bbox_x0 <= x_max
-                                  and x_min <= bbox_x1 <= x_max
-                                  and y_min <= bbox_y0 <= y_max
-                                  and y_min <= bbox_y1 <= y_max):
+        if epsg_code is None and (x_min <= bbox_x0 <= x_max and
+                                    x_min <= bbox_x1 <= x_max and
+                                    y_min <= bbox_y0 <= y_max and
+                                    y_min <= bbox_y1 <= y_max):
             # set default epsg code
             epsg_code = '4326'
         elif epsg_code is None:

--- a/geonode/maps/templates/maps/map_leaflet.html
+++ b/geonode/maps/templates/maps/map_leaflet.html
@@ -39,7 +39,7 @@
         var wmsLayer = null;
 
         /* set coordinate systems */
-        var firstProjection = proj4('EPSG:3857');   // google mercator
+        var firstProjection = proj4('{{ resource.srid }}');   // google mercator
         var secondProjection = proj4('EPSG:4326');  // WGS84 web mercator
 
         /* transform {{resource}} point coordinates from google mercator to WSG84 system */

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -168,6 +168,10 @@ def qgis_server_post_save(instance, sender, **kwargs):
             layer = datasource[0]
             srs = layer.srs
             srs.identify_epsg()
+            srid_string = 'EPSG:{0}'.format(srs.srid)
+            if srid_string == instance.srid:
+                # We have a proper srid here
+                skip_bound_transform = True
         except SRSException as e:
             # GDAL can't find matching EPSG code
             # We will let QGIS handle on the fly projection
@@ -183,6 +187,7 @@ def qgis_server_post_save(instance, sender, **kwargs):
     elif is_raster_layer:
         srs = SpatialReference(instance.srid)
 
+    # Transform bounds to EPSG:4326 when we have undefined projection
     if not skip_bound_transform:
         bound_geom = OGRGeometry.from_bbox((
             instance.bbox_x0, instance.bbox_y0,

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -471,6 +471,13 @@ class GeoNodeMapTest(TestCase):
                 uploaded.metadata_xml = thelayer_metadata
                 regions_resolved, regions_unresolved = resolve_regions(regions)
                 self.assertIsNotNone(regions_resolved)
+        except GeoNodeException, e:
+            # layer have projection file, but has no valid srid
+            self.assertEqual(
+                str(e),
+                "Invalid Layers. "
+                "Needs an authoritative SRID in its CRS to be accepted")
+
         # except:
         #     # Sometimes failes with the message:
         #     # UploadError: Could not save the layer air_runways,

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -471,12 +471,6 @@ class GeoNodeMapTest(TestCase):
                 uploaded.metadata_xml = thelayer_metadata
                 regions_resolved, regions_unresolved = resolve_regions(regions)
                 self.assertIsNotNone(regions_resolved)
-        except GeoNodeException, e:
-            # layer have projection file, but has no valid srid
-            self.assertEqual(
-                str(e),
-                "Invalid Layers. "
-                "Needs an authoritative SRID in its CRS to be accepted")
 
         # except:
         #     # Sometimes failes with the message:


### PR DESCRIPTION
# Fix bbox projection for leaflet in QGIS Server

- Let GeoServer and QGIS Server handle misprojection issues if GeoNode can't handle it
- QGIS Server will always transform bbox to EPSG 4326 to work consistently with leaflet
- QGIS Server thumbnail request will try to maintain aspect ratios of the
  requested extent to avoid squashed image

# Notes

- Most of the problem is because main geonode docker image uses GDAL 1. It can't detect most EPSG. This is fixed in: https://github.com/kartoza/geonode-docker/commit/db60cae03b78a1addfeb468f5a9b3e6117d029b7
- Even if using GDAL 2, sometimes it can't detect correct EPSG code (which is needed to draw correct bbox in leaflet). GeoServer can detect it correctly. In our case (QGIS Server) we transform the bbox to EPSG:4326 by default. The actual CRS is preserved in the file and handled by QGIS. Example layer is in gisdata package Air_Runways.shp

# Issue links

- Override this PR: #442 , #439 
- Fix #374