### PR TITLE
Add basemap to QGIS Project

### DIFF
--- a/docker-compose-qgis-server.yml
+++ b/docker-compose-qgis-server.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   qgis-server:
-    image: kartoza/geonode_qgis-server
+    image: kartoza/qgis-server:2.18
     volumes:
       # Mount this volume from current directory to
       # The absolute path, so these files were mounted

--- a/geonode/client/templates/leaflet/layers/layer_leaflet_map.html
+++ b/geonode/client/templates/leaflet/layers/layer_leaflet_map.html
@@ -138,6 +138,17 @@
             'OpenStreetMap': osm
         };
 
+        {# Extra basemap tiles from LEAFLET_CONFIG #}
+        {% if LEAFLET_CONFIG and LEAFLET_CONFIG.TILES %}
+            {% for tile in LEAFLET_CONFIG.TILES %}
+
+                base_maps["{{ tile.0 }}"] = L.tileLayer('{{ tile.1|safe }}', {
+                    attribution: '{{ tile.2|safe }}'
+                });
+
+            {% endfor %}
+        {% endif %}
+
         var overlay_layer = {};
 
         var map = L.map('preview_map',{measureControl: true});
@@ -171,7 +182,8 @@
         L.control.watermark({ position: 'bottomright' }).addTo(map);
 
         // L.control.measureControl.addTo(map);
-        map.addLayer(OpenMapSurfer_Roads);
+        map.current_base_layer = base_maps[Object.keys(base_maps)[0]];
+        map.addLayer(map.current_base_layer);
 
         {% if layer_bbox %}
             zoom_to_box(map, [{{ layer_bbox }}]);
@@ -212,6 +224,10 @@
         var layerControl = L.control.layers(
                 base_maps, overlay_layer
         ).addTo(map);
+
+        map.on('baselayerchange', function (e) {
+            map.current_base_layer = e.layer;
+        });
 
         if (L.control.hasOwnProperty('fullscreen')) {
             L.control.fullscreen().addTo(map);
@@ -281,8 +297,15 @@
         {# Use map extent #}
         var map = window.preview_map;
         var bbox = map.getBounds().toBBoxString();
+        var current_basemap = L.Util.template(map.current_base_layer._url, {
+            x: '{x}',
+            y: '{y}',
+            z: '{z}',
+            s: 'a'
+        });
         var data = {
-            'bbox': bbox
+            'bbox': bbox,
+            'basemap': current_basemap
         };
         $.post('{% url "qgis_server:set-thumbnail" layername=resource.name %}', data);
     }

--- a/geonode/qgis_server/context_processors.py
+++ b/geonode/qgis_server/context_processors.py
@@ -55,6 +55,10 @@ def qgis_server_urls(request):
                     dict()).get(
                         'MOSAIC_ENABLED',
                         False),
+        LEAFLET_CONFIG=getattr(
+            settings,
+            "LEAFLET_CONFIG",
+            False)
     )
     defaults['style_upload_form'] = QGISLayerStyleUploadForm()
     return defaults

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -419,8 +419,12 @@ def thumbnail_url(bbox, layers, qgis_project, style=None, internal=True):
     # try to maintain aspect ratios of the image
     max_pixel_count = 512
     max_length = max(height, width)
-    height = height * max_pixel_count / max_length
-    width = width * max_pixel_count / max_length
+    if max_length == 0:
+        height = max_pixel_count
+        width = max_pixel_count
+    else:
+        height = height * max_pixel_count / max_length
+        width = width * max_pixel_count / max_length
 
     query_string = {
         'SERVICE': 'WMS',
@@ -811,8 +815,10 @@ def style_list(layer, internal=True, generating_qgis_capabilities=False):
         response = requests.get(url)
 
         root_xml = etree.fromstring(response.content)
+        xpath_query = 'wms:Capability/wms:Layer/wms:Layer' \
+                      '[wms:Name="{0}"]/wms:Style'.format(layer.name)
         styles_xml = root_xml.xpath(
-            'wms:Capability/wms:Layer/wms:Layer/wms:Style',
+            xpath_query,
             namespaces={
                 'xlink': 'http://www.w3.org/1999/xlink',
                 'wms': 'http://www.opengis.net/wms'

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -315,10 +315,19 @@ def qgis_server_post_save(instance, sender, **kwargs):
     # importlayers management command and needs to be overwritten
     overwrite = getattr(instance, 'overwrite', False)
 
+    # default basemap
+    try:
+        default_tile = settings.LEAFLET_CONFIG['TILES'][0]
+        basemap_name = 'basemap'
+        basemap_url = default_tile[1]
+    except BaseException:
+        basemap_name = None
+        basemap_url = None
+
     # Create the QGIS Project
     response = create_qgis_project(
         instance, qgis_layer.qgis_project_path, overwrite=overwrite,
-        internal=True)
+        internal=True, basemap=basemap_url, basemap_name=basemap_name)
 
     logger.debug('Creating the QGIS Project : %s' % response.url)
     if response.content != 'OK':

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -276,8 +276,10 @@ class QGISServerViewsTest(LiveServerTestCase):
         layer_xml = root.xpath(
             'wms:Capability/wms:Layer/wms:Layer/wms:Name',
             namespaces={'wms': 'http://www.opengis.net/wms'})
-        self.assertEqual(len(layer_xml), 1)
-        self.assertEqual(layer_xml[0].text, uploaded.name)
+        # We have the basemap layer and the layer itself
+        self.assertEqual(len(layer_xml), 2)
+        self.assertEqual(layer_xml[0].text, 'basemap')
+        self.assertEqual(layer_xml[1].text, uploaded.name)
         # GetLegendGraphic request returned must be valid
         layer_xml = root.xpath(
             'wms:Capability/wms:Layer/'
@@ -286,7 +288,7 @@ class QGISServerViewsTest(LiveServerTestCase):
                 'xlink': 'http://www.w3.org/1999/xlink',
                 'wms': 'http://www.opengis.net/wms'
             })
-        legend_url = layer_xml[0].attrib[
+        legend_url = layer_xml[1].attrib[
             '{http://www.w3.org/1999/xlink}href']
 
         response = self.client.get(legend_url)
@@ -491,11 +493,10 @@ class QGISServerStyleManagerTest(LiveServerTestCase):
         self.assertEqual(response.status_code, 201)
 
         actual_list_style = style_list(layer, internal=False)
-        if actual_list_style:
-            expected_list_style = ['default', 'new_style']
-            self.assertEqual(
-                set(expected_list_style),
-                set([style.name for style in actual_list_style]))
+        expected_list_style = ['default', 'new_style']
+        self.assertEqual(
+            set(expected_list_style),
+            set([style.name for style in actual_list_style]))
 
         # Test delete request
         delete_style_url = reverse(
@@ -508,11 +509,10 @@ class QGISServerStyleManagerTest(LiveServerTestCase):
         self.assertEqual(response.status_code, 200)
 
         actual_list_style = style_list(layer, internal=False)
-        if actual_list_style:
-            expected_list_style = ['new_style']
-            self.assertEqual(
-                set(expected_list_style),
-                set([style.name for style in actual_list_style]))
+        expected_list_style = ['new_style']
+        self.assertEqual(
+            set(expected_list_style),
+            set([style.name for style in actual_list_style]))
 
         # Check new default
         default_style_url = reverse(

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -31,8 +31,6 @@ import datetime
 import requests
 import shutil
 from django.conf import settings
-from django.contrib.gis.gdal import SpatialReference, CoordTransform, \
-    OGRGeometry
 from django.core.urlresolvers import reverse
 from django.forms.models import model_to_dict
 from django.http import HttpResponse, Http404

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1011,9 +1011,23 @@ LEAFLET_CONFIG = {
         # Find tiles at:
         # http://leaflet-extras.github.io/leaflet-providers/preview/
 
+        # Base map
+        ('OpenMapSurfer_Roads',
+         'http://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}',
+         'Imagery from <a href="http://giscience.uni-hd.de/">'
+         'GIScience Research Group @ University of Heidelberg</a> '
+         '&mdash; Map data &copy;'
+         ' <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+         ),
+        ('OpenStreetMap',
+         'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
+         '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> '
+         'contributors'
+         ),
+
         # Stamen toner lite.
         ('Watercolor',
-         'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+         'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg',
          'Map tiles by <a href="http://stamen.com">Stamen Design</a>, \
          <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> \
          &mdash; Map data &copy; \


### PR DESCRIPTION
# Summary

- We can optionally add default basemap to QGIS Project for Layer
- We can use that basemap to create thumbnail
- Choose different basemap via Layer Detail --> Set Thumbnail

# Notes

- Needs https://github.com/kartoza/otf-project/pull/12
- Overrides/follow up https://github.com/kartoza/geonode/pull/446