### PR TITLE
change wording in Metadata Detail page

### DIFF
--- a/geonode/templates/metadata_detail.html
+++ b/geonode/templates/metadata_detail.html
@@ -174,7 +174,7 @@
         <dt>{% trans "Spatial Extent" %}</dt>
         <dd>{% if resource.scale %} {{ resource.scale }} {% else %} --- {% endif %}</dd>
 
-        <dt>{% trans "Projection System" %}</dt>
+        <dt>{% trans "Coordinate Reference System" %}</dt>
         <dd>{{ resource.srid }}</dd>
 
         <dt>{% trans "Extension x0" %}</dt>


### PR DESCRIPTION
change `Projection System` into `Coordinate Reference System` in Metadata Detail page

fix #418