### PR TITLE
Handle missprojection for raster layer reupload

### DIFF
--- a/dev_config.yml
+++ b/dev_config.yml
@@ -1,6 +1,6 @@
 ---
-GEOSERVER_URL: "http://build.geonode.org/geoserver/latest/geoserver-2.12.2.war"
-DATA_DIR_URL: "http://build.geonode.org/geoserver/latest/data-2.12.2.zip"
+GEOSERVER_URL: "http://build.geo-solutions.it/geonode/geoserver/latest/geoserver-2.13.x.war"
+DATA_DIR_URL: "http://build.geo-solutions.it/geonode/geoserver/latest/data-2.13.x.zip"
 JETTY_RUNNER_URL: "http://repo2.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.7.v20170914/jetty-runner-9.4.7.v20170914.jar"
 WINDOWS:
   py2exe: "http://downloads.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.win32-py2.7.exe"

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -594,7 +594,7 @@ def file_upload(filename,
     # and the layer was not just created
     # process the layer again after that by
     # doing a layer.save()
-    if not created and overwrite:
+    if metadata_upload_form or (not created and overwrite):
         # Replace metadata file if only updated metadata
         if metadata_upload_form:
             # Replace metadata content with the new one
@@ -604,6 +604,7 @@ def file_upload(filename,
 
             if not created:
                 xml_filename = metadata_file.file.name
+                metadata_file.file.delete()
             else:
                 # use the same name
                 base_file, _ = layer.get_base_file()

--- a/geonode/qgis_server/models.py
+++ b/geonode/qgis_server/models.py
@@ -157,6 +157,19 @@ class QGISServerLayer(models.Model, PermissionLevelMixin):
         """
         return '{prefix}.qml'.format(prefix=self.qgis_layer_path_prefix)
 
+    @property
+    def xml_path(self):
+        """Returned the location of XML path for this layer (if any).
+
+        Example base path: /usr/src/app/geonode/qgis_layer/jakarta_flood.shp
+
+        QGIS QML path: /usr/src/app/geonode/qgis_tiles/jakarta_flood.xml
+
+        :return: Base path of xml style
+        :rtype: str
+        """
+        return '{prefix}.xml'.format(prefix=self.qgis_layer_path_prefix)
+
     def delete_qgis_layer(self):
         """Delete all files related to this object from disk."""
         for file_path in self.files:

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -327,7 +327,7 @@ class QGISServerViewsTest(LiveServerTestCase):
                 'wms': 'http://www.opengis.net/wms'
             })
 
-        self.assertEqual(
+        self.assertXMLEqual(
             etree.tostring(layer_xml[0]),
             etree.tostring(response_layer_xml[0]))
 

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -254,7 +254,6 @@ class NormalUserTest(TestCase):
             new_xml_file,
             name="san_andres_y_providencia_poi_by_norman",
             user=norman,
-            overwrite=True,
             metadata_upload_form=True)
 
         # Should be the same layer, just updated


### PR DESCRIPTION
- Improve unittests for Layer Metadata Upload (overwrite flag=False, like in the form)
- Refactor missprojection handling for QGIS Server Raster layer
- Change build server URL. Fix #501 