### PR TITLE
Change for proper SITEURL format in invitation email

### DIFF
--- a/geonode/people/adapters.py
+++ b/geonode/people/adapters.py
@@ -141,9 +141,9 @@ class LocalAccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
             "inviter_first_name": user.first_name or str(user),
             "inviter_id": user.id,
             "groups": user_groups,
-            "MEDIA_URL": settings.MEDIA_URL,
-            "SITEURL": settings.SITEURL,
-            "STATIC_URL": settings.STATIC_URL
+            "MEDIA_URL": settings.MEDIA_URL.strip('/'),
+            "SITEURL": settings.SITEURL.strip('/'),
+            "STATIC_URL": settings.STATIC_URL.strip('/')
         })
         return super(LocalAccountAdapter, self).render_mail(
             template_prefix, email, enhanced_context)


### PR DESCRIPTION
We need to strip base URL from '/' endings, because when it is used in the template, the variable are concatenated directly with relative url from Django reverse. This will avoid URL such as:

```
http://testing.geonode.kartoza.com//relative/url
```