### PR TITLE
Checking for invalid capability URL

### DIFF
--- a/geonode/harvesting/harvesters/wms.py
+++ b/geonode/harvesting/harvesters/wms.py
@@ -42,6 +42,7 @@ from .. import models
 from geonode.utils import (
     XML_PARSER,
     get_xpath_value,
+    url_exists,
 )
 from .. import resourcedescriptor
 
@@ -178,8 +179,10 @@ class OgcWmsHarvester(base.BaseHarvesterWorker):
             if ogc_wms_get_capabilities and ogc_wms_get_capabilities.get("methods", None):
                 for _op_method in ogc_wms_get_capabilities.get("methods"):
                     if _op_method.get("type", None).upper() == "GET" and _op_method.get("url", None):
-                        ogc_wms_url = _op_method.get("url")
-                        break
+                        # Only change the URL if it is not returning 404
+                        if url_exists(_op_method.get("url")):
+                            ogc_wms_url = _op_method.get("url")
+                            break
         except Exception as e:
             logger.exception(e)
         return ogc_wms_url

--- a/geonode/harvesting/harvesters/wms.py
+++ b/geonode/harvesting/harvesters/wms.py
@@ -42,7 +42,7 @@ from .. import models
 from geonode.utils import (
     XML_PARSER,
     get_xpath_value,
-    url_exists,
+    is_url_accessible,
 )
 from .. import resourcedescriptor
 
@@ -180,7 +180,7 @@ class OgcWmsHarvester(base.BaseHarvesterWorker):
                 for _op_method in ogc_wms_get_capabilities.get("methods"):
                     if _op_method.get("type", None).upper() == "GET" and _op_method.get("url", None):
                         # Only change the URL if it is not returning 404
-                        if url_exists(_op_method.get("url")):
+                        if is_url_accessible(_op_method.get("url")):
                             ogc_wms_url = _op_method.get("url")
                             break
         except Exception as e:

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -66,6 +66,9 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models, connection, transaction
+from django.test import Client
+from django.urls import resolve
+from django.urls.exceptions import Resolver404
 from django.utils.translation import gettext_lazy as _
 
 from geonode import geoserver, GeoNodeException  # noqa
@@ -1999,3 +2002,17 @@ def get_supported_datasets_file_types():
 
 def get_allowed_extensions():
     return list(itertools.chain.from_iterable([_type["ext"] for _type in get_supported_datasets_file_types()]))
+
+def url_exists(path: str, user = None) -> bool:
+    """
+    Returns True if the URL exists and will NOT return 404.
+    403, 200, 302 (login redirect) are all treated as valid.
+    """
+    client = Client()
+
+    if user:
+        client.force_login(user)
+
+    response = client.get(path, follow=False)
+
+    return response.status_code != 404

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -66,9 +66,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models, connection, transaction
-from django.test import Client
-from django.urls import resolve
-from django.urls.exceptions import Resolver404
 from django.utils.translation import gettext_lazy as _
 
 from geonode import geoserver, GeoNodeException  # noqa
@@ -2003,16 +2000,20 @@ def get_supported_datasets_file_types():
 def get_allowed_extensions():
     return list(itertools.chain.from_iterable([_type["ext"] for _type in get_supported_datasets_file_types()]))
 
-def url_exists(path: str, user = None) -> bool:
+
+def is_url_accessible(url: str, timeout: int = 5) -> bool:
     """
-    Returns True if the URL exists and will NOT return 404.
-    403, 200, 302 (login redirect) are all treated as valid.
+    Check if an external URL is accessible (does not return 404 or other errors).
+    
+    Args:
+        url: The URL to check
+        timeout: Request timeout in seconds (default: 5)
+    
+    Returns:
+        True if the URL is accessible, False if it returns 404 or fails
     """
-    client = Client()
-
-    if user:
-        client.force_login(user)
-
-    response = client.get(path, follow=False)
-
-    return response.status_code != 404
+    try:
+        response = requests.head(url, timeout=timeout, allow_redirects=True)
+        return response.status_code != 404
+    except requests.RequestException:
+        return False


### PR DESCRIPTION
This PR checks if the capability request link obtained from the GeoServer Proxy Base URL is valid. If the URL returns a 404 error code, then fall back to the originally registered service URL.

Inspired by https://github.com/kartoza/IGRAC-GGIS/issues/618#issuecomment-3738753290